### PR TITLE
Add Ruby 2.0.0 and 2.1.2 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 ---
 language: ruby
 rvm:
-- 1.8.7
-- 1.9.3
-- jruby-19mode
+  - 2.1.2
+  - 2.0.0
+  - 1.9.3
+  - 1.8.7
+  - jruby-19mode
 
 bundler_args: --without=localdev


### PR DESCRIPTION
Would be great to know that Ruby 2.0.0 and 2.1.2 are supported.
