### PR TITLE
Combine multiple messages with "\n".

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -293,7 +293,7 @@ class Statsd
   end
 
   def flush_buffer()
-    send_to_socket(@buffer.join('\n'))
+    send_to_socket(@buffer.join("\n"))
     @buffer = Array.new
   end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -354,7 +354,7 @@ describe Statsd do
             s.increment("mycounter")
             s.decrement("myothercounter")
         end
-        @statsd.socket.recv.must_equal ['mycounter:1|c\nmyothercounter:-1|c']
+        @statsd.socket.recv.must_equal ["mycounter:1|c\nmyothercounter:-1|c"]
       end
 
       it "should default back to single metric packet after the block" do
@@ -364,7 +364,7 @@ describe Statsd do
         end
         @statsd.increment("mycounter")
         @statsd.increment("myothercounter")
-        @statsd.socket.recv.must_equal ['mygauge:10|g\nmyothergauge:20|g']
+        @statsd.socket.recv.must_equal ["mygauge:10|g\nmyothergauge:20|g"]
         @statsd.socket.recv.must_equal ['mycounter:1|c']
         @statsd.socket.recv.must_equal ['myothercounter:1|c']
       end
@@ -382,7 +382,7 @@ describe Statsd do
           50.times do
             theoretical_reply.push('mycounter:1|c')
           end
-          @statsd.socket.recv.must_equal [theoretical_reply.join('\n')]
+          @statsd.socket.recv.must_equal [theoretical_reply.join("\n")]
         end
 
         # When the block finishes, the remaining buffer is flushed


### PR DESCRIPTION
Multiple messages sent to statsd must be combined with `"\n"`. In Ruby, `'\n'` is the same as `"\\n"`.

Without this patch, I experimented the following error:

```
2014-09-09 11:07:55,278 | ERROR | dd.dogstatsd | dogstatsd(dogstatsd.py:253) | Error receiving datagram
Traceback (most recent call last):
  File "/usr/share/datadog/agent/dogstatsd.py", line 244, in start
    aggregator_submit(socket_recv(buffer_size))
  File "/usr/share/datadog/agent/aggregator.py", line 374, in submit_packets
    self.submit_metric(name, value, mtype, tags=tags, sample_rate=sample_rate)
  File "/usr/share/datadog/agent/aggregator.py", line 384, in submit_metric
    metric_class = self.metric_type_to_class[mtype]
KeyError: 'h\\nmetric.name:12345'
```
