### PR TITLE
use send_stat instead of overriding ruby send method

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -255,12 +255,13 @@ class Statsd
     raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8 * 1024
     return event_string_data
   end
-  
-  private
-  
+
   def prefix
     @namespace.to_s.length > 0 ? "#{@namespace}:" : ""
   end
+  
+  private
+  
 
   def escape_event_content(msg)
     msg = msg.sub! "\n", "\\n"

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -72,7 +72,7 @@ class Statsd
     self.tags = opts[:tags]
     @buffer = Array.new
     self.max_buffer_size = max_buffer_size
-    alias :send :send_to_socket
+    alias :send_stat :send_to_socket
   end
 
   def namespace=(namespace) #:nodoc:
@@ -232,10 +232,10 @@ class Statsd
   #      s.increment('page.views')
   #    end
   def batch()
-    alias :send :send_to_buffer
+    alias :send_stat :send_to_buffer
     yield self
     flush_buffer
-    alias :send :send_to_socket
+    alias :send_stat :send_to_socket
   end
 
   def format_event(title, text, opts={})
@@ -281,7 +281,7 @@ class Statsd
       rate = "|@#{sample_rate}" unless sample_rate == 1
       ts = (tags || []) + (opts[:tags] || [])
       tags = "|##{ts.join(",")}" unless ts.empty?
-      send "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
+      send_stat "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
     end
   end
 

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -63,23 +63,19 @@ class Statsd
   # @option opts [String] :namespace set a namespace to be prepended to every metric name
   # @option opts [Array<String>] :tags tags to be added to every metric
   def initialize(opts = {})
-    
+
     @host = opts[:host] || DEFAULT_HOST
     @port = opts[:port] || DEFAULT_PORT
     @namespace = opts[:namespace]
     @max_buffer_size = opts[:max_buffer_size]
     @tags = opts[:tags]
-    
+
     @socket = UDPSocket.new
     @buffer = Array.new
 
     # Start by _not_ buffering
     alias :send_stat :send_to_socket
 
-  end
-
-  def tags=(tags) #:nodoc:
-    @tags = tags || []
   end
 
   # Sends an increment (count = 1) for the given stat to the statsd server.
@@ -259,15 +255,15 @@ class Statsd
   def prefix
     @namespace.to_s.length > 0 ? "#{@namespace}." : ""
   end
-  
+
   private
-  
 
   def escape_event_content(msg)
-    msg = msg.sub! "\n", "\\n"
+    msg.sub! "\n", "\\n"
   end
+
   def rm_pipes(msg)
-    msg = msg.sub! "|", ""
+    msg.sub! "|", ""
   end
 
   def send_stats(stat, delta, type, opts={})
@@ -276,7 +272,7 @@ class Statsd
       # Replace Ruby module scoping with '.' and reserved chars (: | @) with underscores.
       stat = stat.to_s.gsub('::', '.').tr(':|@', '_')
       rate = "|@#{sample_rate}" unless sample_rate == 1
-      ts = (tags || []) + (opts[:tags] || [])
+      ts = (@tags || []) + (opts[:tags] || [])
       tags = "|##{ts.join(",")}" unless ts.empty?
       send_stat "#{self.prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
     end

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -257,7 +257,7 @@ class Statsd
   end
 
   def prefix
-    @namespace.to_s.length > 0 ? "#{@namespace}:" : ""
+    @namespace.to_s.length > 0 ? "#{@namespace}." : ""
   end
   
   private

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -8,7 +8,7 @@ describe Statsd do
   end
 
   before do
-    @statsd = Statsd.new('localhost', 1234)
+    @statsd = Statsd.new(:host => 'localhost', :port => 1234)
     @statsd.socket = FakeUDPSocket.new
   end
 
@@ -29,11 +29,11 @@ describe Statsd do
     end
 
     it 'should be able to set host, port, namespace, and global tags' do
-      statsd = Statsd.new '1.3.3.7', 8126, :tags => %w(global), :namespace => 'space'
+      statsd = Statsd.new :host => '1.3.3.7', :port => 8126, :tags => %w(global), :namespace => 'space'
       statsd.host.must_equal '1.3.3.7'
       statsd.port.must_equal 8126
       statsd.namespace.must_equal 'space'
-      statsd.instance_variable_get('@prefix').must_equal 'space.'
+      statsd.prefix.must_equal 'space.'
       statsd.tags.must_equal ['global']
     end
   end


### PR DESCRIPTION
in some implementations of the code we might want to call something like:

type = :increment

$statsd.send(type, my_stat)

but this would not work because send has been aliased to one of send_to_buffer or send_to_socket