### PR TITLE
statsd.event now also takes into account the common tags

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -252,25 +252,26 @@ class Statsd
         event_string_data << "|#{name_key[1]}:#{value}"
       end
     end
-    tags = opts[:tags] || nil
+    full_tags = tags + (opts[:tags] || [])
     # Tags are joined and added as last part to the string to be sent
-    if tags
-      tags.each do |tag|
+    unless full_tags.empty?
+      full_tags.each do |tag|
         rm_pipes tag
       end
-      tags = "#{tags.join(",")}" unless tags.empty?
-      event_string_data << "|##{tags}"
+      event_string_data << "|##{full_tags.join(',')}"
     end
 
     raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8 * 1024
     return event_string_data
   end
+
   private
+
   def escape_event_content(msg)
-    msg = msg.sub! "\n", "\\n"
+    msg.sub! "\n", "\\n"
   end
   def rm_pipes(msg)
-    msg = msg.sub! "|", ""
+    msg.sub! "|", ""
   end
 
   def send_stats(stat, delta, type, opts={})

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -451,6 +451,20 @@ describe Statsd do
         @statsd.event(title, text, :tags => tags)
         @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|##{tags_joined}"]
       end
+      it "Takes into account the common tags" do
+        basic_result = @statsd.format_event(title, text)
+        common_tag = 'common'
+        @statsd.instance_variable_set :@tags, [common_tag]
+        @statsd.event(title, text)
+        @statsd.socket.recv.must_equal ["#{basic_result}|##{common_tag}"]
+      end
+      it "combines common and specific tags" do
+        basic_result = @statsd.format_event(title, text)
+        common_tag = 'common'
+        @statsd.instance_variable_set :@tags, [common_tag]
+        @statsd.event(title, text, :tags => tags)
+        @statsd.socket.recv.must_equal ["#{basic_result}|##{common_tag},#{tags_joined}"]
+      end
       it "With alert_type, priority, hostname, several tags" do
         @statsd.event(title, text, :alert_type => 'warning', :priority => 'low', :hostname => 'hostname_test', :tags => tags)
         opts = {


### PR DESCRIPTION
This fixes the fact that statsd.event wasn't accounting for the common tags options
Added 2 test cases on that

+ minor cleanup in the escape_event_content and rm_pipes methods