### PR TITLE
use send_stat instead of overriding ruby send method

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -84,7 +84,7 @@ class Statsd
     self.tags = opts[:tags]
     @buffer = Array.new
     self.max_buffer_size = max_buffer_size
-    alias :send :send_to_socket
+    alias :send_stat :send_to_socket
   end
 
   def namespace=(namespace) #:nodoc:
@@ -293,10 +293,10 @@ class Statsd
   #      s.increment('page.views')
   #    end
   def batch()
-    alias :send :send_to_buffer
+    alias :send_stat :send_to_buffer
     yield self
     flush_buffer
-    alias :send :send_to_socket
+    alias :send_stat :send_to_socket
   end
 
   def format_event(title, text, opts={})
@@ -353,7 +353,7 @@ class Statsd
       rate = "|@#{sample_rate}" unless sample_rate == 1
       ts = (tags || []) + (opts[:tags] || [])
       tags = "|##{ts.join(",")}" unless ts.empty?
-      send "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
+      send_stat "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
     end
   end
 


### PR DESCRIPTION
Cherry-picked from #13 to avoid backward incompatibilities, and rebased. Thanks again @sensadrome !