### PR TITLE
Allow closing the UDP socket

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -376,4 +376,9 @@ class Statsd
     self.class.logger.error { "Statsd: #{boom.class} #{boom}" } if self.class.logger
     nil
   end
+
+  # Close the underlying socket
+  def close()
+    @socket.close
+  end
 end


### PR DESCRIPTION
Otherwise the sockets used by Statsd objects that get unreferenced are closed only once GC kicks in.