### PR TITLE
Fix missing trailing '

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 The `Statsd` is now namespaced under the Datadog module.
 
 To update:
-- `require 'statsd'` -> `require 'datadog/statsd`
+- `require 'statsd'` -> `require 'datadog/statsd'`
 - `Statsd` -> `Datadog::Statsd`
 
 #### Tags


### PR DESCRIPTION
Super trivial fix, but helpful for copy/paste.