### PR TITLE
Use histogram type to send timing data.

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -169,10 +169,13 @@ module Datadog
       send_stats stat, value, :h, opts
     end
 
-    # Sends a timing (in ms) for the given stat to the statsd server. The
+    # Sends a histogram (in ms) for the given stat to the statsd server. The
     # sample_rate determines what percentage of the time this report is sent. The
     # statsd server then uses the sample_rate to correctly track the average
     # timing for the stat.
+    #
+    # Note: This is identical to the histogram method above.  We do not send
+    # :ms since Datadog does not support that type.
     #
     # @param [String] stat stat name
     # @param [Integer] ms timing in milliseconds
@@ -180,7 +183,7 @@ module Datadog
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
     # @option opts [Array<String>] :tags An array of tags
     def timing(stat, ms, opts={})
-      send_stats stat, ms, :ms, opts
+      send_stats stat, ms, :h, opts
     end
 
     # Reports execution time of the provided block using {#timing}.

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -156,14 +156,14 @@ describe Datadog::Statsd do
   describe "#timing" do
     it "should format the message according to the statsd spec" do
       @statsd.timing('foobar', 500)
-      @statsd.socket.recv.must_equal ['foobar:500|ms']
+      @statsd.socket.recv.must_equal ['foobar:500|h']
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.timing('foobar', 500, :sample_rate=>0.5)
-        @statsd.socket.recv.must_equal ['foobar:500|ms|@0.5']
+        @statsd.socket.recv.must_equal ['foobar:500|h|@0.5']
       end
     end
   end
@@ -183,7 +183,7 @@ describe Datadog::Statsd do
         @statsd.time('foobar') do
           Timecop.freeze(Time.now + 1)
         end
-        @statsd.socket.recv.must_equal ['foobar:1000|ms']
+        @statsd.socket.recv.must_equal ['foobar:1000|h']
       end
 
       it "should still time if block is failing" do
@@ -191,7 +191,7 @@ describe Datadog::Statsd do
           Timecop.freeze(Time.now + 1)
           raise StandardError, 'This is failing'
         end rescue
-        @statsd.socket.recv.must_equal ['foobar:1000|ms']
+        @statsd.socket.recv.must_equal ['foobar:1000|h']
       end
     end
 
@@ -220,7 +220,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; raise end; end }
       it "should send" do
         @statsd.timing('foobar', 500, :sample_rate=>1)
-        @statsd.socket.recv.must_equal ['foobar:500|ms']
+        @statsd.socket.recv.must_equal ['foobar:500|h']
       end
     end
 
@@ -228,7 +228,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should send" do
         @statsd.timing('foobar', 500, :sample_rate=>0.5)
-        @statsd.socket.recv.must_equal ['foobar:500|ms|@0.5']
+        @statsd.socket.recv.must_equal ['foobar:500|h|@0.5']
       end
     end
 
@@ -243,7 +243,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should send" do
         @statsd.timing('foobar', 500, :sample_rate=>0.5)
-        @statsd.socket.recv.must_equal ['foobar:500|ms|@0.5']
+        @statsd.socket.recv.must_equal ['foobar:500|h|@0.5']
       end
     end
   end
@@ -263,7 +263,7 @@ describe Datadog::Statsd do
 
     it "should add namespace to timing" do
       @statsd.timing('foobar', 500)
-      @statsd.socket.recv.must_equal ['service.foobar:500|ms']
+      @statsd.socket.recv.must_equal ['service.foobar:500|h']
     end
 
     it "should add namespace to gauge" do
@@ -355,7 +355,7 @@ describe Datadog::Statsd do
 
     it "timing support tags" do
       @statsd.timing("t", 200, :tags=>%w(country:canada other))
-      @statsd.socket.recv.must_equal ['t:200|ms|#country:canada,other']
+      @statsd.socket.recv.must_equal ['t:200|h|#country:canada,other']
 
       @statsd.time('foobar', :tags => ["123"]) { sleep(0.001); 'test' }
     end


### PR DESCRIPTION
Based on Datadog's docs dogstatsd doesn't support the timing metric, so using histogram instead.