### PR TITLE
Replace string literals with symbols or frozen strings

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -333,6 +333,9 @@ module Datadog
     DOUBLE_COLON = "::".freeze
     UNDERSCORE = "_".freeze
 
+    private_constant :NEW_LINE, :ESC_NEW_LINE, :COMMA, :BLANK, :PIPE, :DOT,
+      :DOUBLE_COLON, :UNDERSCORE
+
     def escape_event_content(msg)
       msg.gsub NEW_LINE, ESC_NEW_LINE
     end

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -244,7 +244,7 @@ module Datadog
 
         if key == :tags
           tags = opts[:tags].map {|tag| escape_tag_content(tag) }
-          tags = "#{tags.join(",")}" unless tags.empty?
+          tags = "#{tags.join(COMMA)}" unless tags.empty?
           sc_string << "|##{tags}"
         elsif key == :message
           message = remove_pipes(opts[:message])
@@ -315,7 +315,7 @@ module Datadog
       # Tags are joined and added as last part to the string to be sent
       full_tags = (tags + (opts[:tags] || [])).map {|tag| escape_tag_content(tag) }
       unless full_tags.empty?
-        event_string_data << "|##{full_tags.join(',')}"
+        event_string_data << "|##{full_tags.join(COMMA)}"
       end
 
       raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8192 # 8 * 1024 = 8192
@@ -363,7 +363,7 @@ module Datadog
         stat = stat.to_s.gsub(DOUBLE_COLON, DOT).tr(':|@'.freeze, UNDERSCORE)
         rate = "|@#{sample_rate}" unless sample_rate == 1
         ts = (tags || []) + (opts[:tags] || []).map {|tag| escape_tag_content(tag)}
-        tags = "|##{ts.join(",")}" unless ts.empty?
+        tags = "|##{ts.join(COMMA)}" unless ts.empty?
         send_stat "#{@prefix}#{stat}:#{delta}|#{type}#{rate}#{tags}"
       end
     end
@@ -376,7 +376,7 @@ module Datadog
     end
 
     def flush_buffer()
-      send_to_socket(@buffer.join("\n"))
+      send_to_socket(@buffer.join(NEW_LINE))
       @buffer = Array.new
     end
 

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -19,7 +19,7 @@ require 'socket'
 module Datadog
   class Statsd
 
-    DEFAULT_HOST = '127.0.0.1'.freeze
+    DEFAULT_HOST = '127.0.0.1'
     DEFAULT_PORT = 8125
 
     # Create a dictionary to assign a key to every parameter's name, except for tags (treated differently)

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -318,7 +318,7 @@ module Datadog
         event_string_data << "|##{full_tags.join(',')}"
       end
 
-      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8 * 1024
+      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8192 # 8 * 1024 = 8192
       return event_string_data
     end
 


### PR DESCRIPTION
## Context

Ruby strings take up new spots of memory every time they are used. Generally it's not a problem but the memory adds up at scale. Symbols and frozen strings will always occupy the same spot in memory, which reduces the memory load and increases performance.

## This Change

- Convert some of the strings to symbols. I did this in places that it made sense for them to be symbols anyway (e.g. the strings that were getting `to_sym`-ed)
- Freeze the strings that will not be changing and are used multiple times per call
- Convert the array of arrays to hashes and use named arguments for the key and value when iterating over the hashes.

@jnunemaker @aroben @vmg can you take a look at this and let me know what you think/if I'm missing something? 🙏 💖 