### PR TITLE
`#time`: record on all block exits.

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -199,12 +199,9 @@ module Datadog
     #   $statsd.time('account.activate') { @account.activate! }
     def time(stat, opts={})
       start = Time.now
-      result = yield
+      return yield
+    ensure
       time_since(stat, start, opts)
-      result
-    rescue
-      time_since(stat, start, opts)
-      raise
     end
     # Sends a value to be tracked as a set to the statsd server.
     #

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -193,6 +193,18 @@ describe Datadog::Statsd do
         end rescue
         @statsd.socket.recv.must_equal ['foobar:1000|ms']
       end
+
+      def helper_time_return
+        @statsd.time('foobar') do
+          Timecop.freeze(Time.now + 1)
+          return
+        end
+      end
+
+      it "should still time if block `return`s" do
+        helper_time_return
+        @statsd.socket.recv.must_equal ['foobar:1000|ms']
+      end
     end
 
     it "should return the result of the block" do


### PR DESCRIPTION
The previous implementation would not report if a block exited via
early-`return`, or other abnormal terminations (e.g. `break` or
`throw`). That is confusing behavior; I expect a `time` block to always
report the time spend inside the passed the block.