### PR TITLE
Expose flush_buffer for customizable interval flushing

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -329,6 +329,11 @@ module Datadog
       return event_string_data
     end
 
+    def flush_buffer()
+      send_to_socket(@buffer.join(NEW_LINE))
+      @buffer = Array.new
+    end
+    
     private
 
     NEW_LINE = "\n".freeze
@@ -418,11 +423,6 @@ module Datadog
       if @buffer.length >= @max_buffer_size
         flush_buffer
       end
-    end
-
-    def flush_buffer()
-      send_to_socket(@buffer.join(NEW_LINE))
-      @buffer = Array.new
     end
 
     def send_to_socket(message)


### PR DESCRIPTION
We use dogstatsd in a high-performance environment so we need more granular control over the flushing rate and chose to implement an event loop that controls our flushing mechanism rather than depending on the `max_buffer_size`