### PR TITLE
Optimized sending

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -87,7 +87,7 @@ module Datadog
     def initialize(host = DEFAULT_HOST, port = DEFAULT_PORT, opts = {}, max_buffer_size=50)
       self.host, self.port = host, port
       @prefix = nil
-      @socket = UDPSocket.new
+      @socket = connect_to_socket(host, port)
       self.namespace = opts[:namespace]
       self.tags = opts[:tags]
       @buffer = Array.new
@@ -425,9 +425,15 @@ module Datadog
       @buffer = Array.new
     end
 
+    def connect_to_socket(host, port)
+      socket = UDPSocket.new
+      socket.connect(host, port)
+      socket
+    end
+
     def send_to_socket(message)
       self.class.logger.debug { "Statsd: #{message}" } if self.class.logger
-      @socket.send(message, 0, @host, @port)
+      @socket.send(message, 0)
     rescue => boom
       self.class.logger.error { "Statsd: #{boom.class} #{boom}" } if self.class.logger
       nil

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -24,7 +24,7 @@ describe Datadog::Statsd do
       statsd = Datadog::Statsd.new
       statsd.host.must_equal '127.0.0.1'
       statsd.port.must_equal 8125
-      statsd.namespace.must_equal nil
+      assert_nil statsd.namespace
       statsd.tags.must_equal []
     end
 
@@ -68,8 +68,8 @@ describe Datadog::Statsd do
 
     it 'should set prefix to nil when namespace is set to nil' do
       @statsd.namespace = nil
-      @statsd.namespace.must_equal nil
-      @statsd.instance_variable_get('@prefix').must_equal nil
+      assert_nil @statsd.namespace
+      assert_nil @statsd.instance_variable_get('@prefix')
     end
 
     it 'should set nil tags to default' do
@@ -261,7 +261,7 @@ describe Datadog::Statsd do
     describe "when the sample rate is less than a random value [0,1]" do
       before { class << @statsd; def rand; 1; end; end } # ensure no delivery
       it "should not send" do
-        @statsd.timing('foobar', 500, :sample_rate=>0.5).must_equal nil
+        assert_nil @statsd.timing('foobar', 500, :sample_rate=>0.5)
       end
     end
 
@@ -360,7 +360,7 @@ describe Datadog::Statsd do
     end
 
     it "should ignore socket errors" do
-      @statsd.increment('foobar').must_equal nil
+      assert_nil @statsd.increment('foobar')
     end
 
     it "should log socket errors" do


### PR DESCRIPTION
Hey there,
First of all thank you for your effort in maintaining this gem. 
We're using this gem in production and observed some weird performance issues when statsd wasn't available during the maintenance. We're still investigating what exactly happened. Anyway I played a bit with UDPSockets and did some benchmarks using this [script](https://gist.github.com/AMekss/71133597e23ec9929a34b2b6452f3e00)

Here is what it looked like:
_When statsd was available_
```
                           user     system      total        real
connect_and_send:      0.070000   0.120000   0.190000 (  0.406062)
just_send:             0.050000   0.100000   0.150000 (  0.279297)
```
_When statsd was down_
```
                           user     system      total        real
connect_and_send:      0.050000   0.100000   0.150000 (  0.156057)
just_send:             0.030000   0.050000   0.080000 (  0.081477)
```
This PR implements performance improvements based on my findings (also I fixed deprecation warnings for the spec run)