### PR TITLE
Exposing #close as a public method, to help consumers avoid using too many file descriptors

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -22,11 +22,7 @@ class FakeUDPSocket
   end
 
   def recv
-    res = @buffer.shift
-  end
-
-  def clear
-    @buffer = []
+    @buffer.shift
   end
 
   def to_s

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'timecop'
+require 'stringio'
 
 describe Datadog::Statsd do
   class Datadog::Statsd
@@ -354,7 +355,6 @@ describe Datadog::Statsd do
 
   describe "handling socket errors" do
     before do
-      require 'stringio'
       Datadog::Statsd.logger = Logger.new(@log = StringIO.new)
       @statsd.socket.instance_eval { def send(*) raise SocketError end }
     end
@@ -365,6 +365,56 @@ describe Datadog::Statsd do
 
     it "should log socket errors" do
       @statsd.increment('foobar')
+      @log.string.must_match 'Statsd: SocketError'
+    end
+  end
+
+  describe "handling closed socket" do
+    before do
+      Datadog::Statsd.logger = Logger.new(@log = StringIO.new)
+    end
+
+    it "should try once to reconnect" do
+      @statsd.socket.instance_eval do
+        def send_calls() @send_calls ; end
+
+        def send(*args)
+          @send_calls ||= 0
+          @send_calls += 1
+          raise IOError.new("closed stream") unless @send_calls > 1
+          super(*args)
+        end
+      end
+      @statsd.instance_eval { def connect_to_socket(*) @socket ; end }
+
+      @statsd.increment('foobar')
+
+      @statsd.socket.send_calls.must_equal 2
+      @statsd.socket.recv.must_equal ["foobar:1|c"]
+    end
+
+    it "should ignore and log if it fails to reconnect" do
+      @statsd.socket.instance_eval do
+        def send_calls() @send_calls ; end
+
+        def send(*)
+          @send_calls ||= 0
+          @send_calls += 1
+          raise IOError.new("closed stream")
+        end
+      end
+      @statsd.instance_eval { def connect_to_socket(*) @socket ; end }
+
+      assert_nil @statsd.increment('foobar')
+      @statsd.socket.send_calls.must_equal 2
+      @log.string.must_match 'Statsd: IOError closed stream'
+    end
+
+    it "should ignore and log errors while trying to reconnect" do
+      @statsd.socket.instance_eval { def send(*) raise IOError.new("closed stream") end }
+      @statsd.instance_eval { def connect_to_socket(*) raise SocketError end }
+
+      assert_nil @statsd.increment('foobar')
       @log.string.must_match 'Statsd: SocketError'
     end
   end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -582,6 +582,17 @@ describe Datadog::Statsd do
 
     end
   end
+
+  describe "#close" do
+    it "closes the socket" do
+      socket = MiniTest::Mock.new
+      socket.expect :close, nil
+      @statsd.socket = socket
+      @statsd.close
+    end
+
+    after { @statsd.socket = FakeUDPSocket.new }
+  end
 end
 
 describe Datadog::Statsd do

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -13,8 +13,6 @@ describe Datadog::Statsd do
     @statsd.socket = FakeUDPSocket.new
   end
 
-  after { @statsd.socket.clear }
-
   describe "#initialize" do
     it "should set the host and port" do
       @statsd.host.must_equal 'localhost'
@@ -640,8 +638,6 @@ describe Datadog::Statsd do
       @statsd.socket = socket
       @statsd.close
     end
-
-    after { @statsd.socket = FakeUDPSocket.new }
   end
 end
 


### PR DESCRIPTION
It seems like a common use case for this client would be logging events in a web server.  Many of these spin up a thread per response, or delegate response to a thread/process pool.  My assumption is that these different threads/processes should not share the same Datadog::Statsd client, since I didn't see any sort of locking implemented around the socket IO.

For our use case, we don't mind creating a new UDPSocket every time we log a set of metrics, so I'd like to be able to close the socket when I'm done to avoid using thousands of file descriptors before the object get garbage collected.  Please let me know if this is acceptable, or if I'm perhaps missing some more common way of using this library.