### PR TITLE
Replaced 'alias' calls with an instance variable.

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -64,6 +64,10 @@ module Datadog
     # Global tags to be added to every statsd call. Defaults to no tags.
     attr_reader :tags
 
+    # True if we should batch up data before sending it, or false if we
+    # want to send data immediately.
+    attr_reader :should_batch
+
     # Buffer containing the statsd message before they are sent in batch
     attr_reader :buffer
 
@@ -92,7 +96,7 @@ module Datadog
       self.tags = opts[:tags]
       @buffer = Array.new
       self.max_buffer_size = max_buffer_size
-      alias :send_stat :send_to_socket
+      @should_batch = false
     end
 
     def namespace=(namespace) #:nodoc:
@@ -299,10 +303,11 @@ module Datadog
     #      s.increment('page.views')
     #    end
     def batch()
-      alias :send_stat :send_to_buffer
+      @should_batch = true
       yield self
       flush_buffer
-      alias :send_stat :send_to_socket
+    ensure
+      @should_batch = false
     end
 
     def format_event(title, text, opts={})
@@ -413,10 +418,12 @@ module Datadog
       end
     end
 
-    def send_to_buffer(message)
-      @buffer << message
-      if @buffer.length >= @max_buffer_size
-        flush_buffer
+    def send_stat(message)
+      if @should_batch
+        @buffer << message
+        flush_buffer if @buffer.length >= @max_buffer_size
+      else
+        send_to_socket(message)
       end
     end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -127,7 +127,7 @@ describe Datadog::Statsd do
   end
 
   describe "#gauge" do
-    it "should send a message with a 'g' type, per the nearbuy fork" do
+    it "should send a message with a 'g' type, per the nearby fork" do
       @statsd.gauge('begrutten-suffusion', 536)
       @statsd.socket.recv.must_equal ['begrutten-suffusion:536|g']
       @statsd.gauge('begrutten-suffusion', -107.3)
@@ -144,7 +144,7 @@ describe Datadog::Statsd do
   end
 
   describe "#histogram" do
-    it "should send a message with a 'h' type, per the nearbuy fork" do
+    it "should send a message with a 'h' type, per the nearby fork" do
       @statsd.histogram('ohmy', 536)
       @statsd.socket.recv.must_equal ['ohmy:536|h']
       @statsd.histogram('ohmy', -107.3)
@@ -161,7 +161,7 @@ describe Datadog::Statsd do
   end
 
   describe "#set" do
-    it "should send a message with a 's' type, per the nearbuy fork" do
+    it "should send a message with a 's' type, per the nearby fork" do
       @statsd.set('my.set', 536)
       @statsd.socket.recv.must_equal ['my.set:536|s']
     end


### PR DESCRIPTION
This fixes two problems with `batch`:

1. Calling `alias` blows out the Ruby method cache for the current class and all its subclasses, so for performance reasons you don't want to be calling `alias` on a regular basis.

2. If an exception occurred while sending the batched data, it would get stuck in batched mode.

Also fixed up a few typos in the specs for fun.