### PR TITLE
`to_s` all the tags

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -411,7 +411,7 @@ module Datadog
 
 
         tag_arr = opts[:tags].to_a
-        tag_arr.map! { |tag| t = tag.dup; escape_tag_content!(t); t }
+        tag_arr.map! { |tag| t = tag.to_s.dup; escape_tag_content!(t); t }
         ts = tags.to_a + tag_arr
         unless ts.empty?
           full_stat << PIPE

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -349,6 +349,11 @@ describe Datadog::Statsd do
     it "handles the cases when some tags are frozen strings" do
       @statsd.increment('stat', tags: ["first_tag".freeze, "second_tag"])
     end
+
+    it "converts all values to strings" do
+      @statsd.increment('stat', tags: [:sample_tag])
+      @statsd.socket.recv.must_equal ['stat:1|c|#sample_tag']
+    end
   end
 
   describe "handling socket errors" do


### PR DESCRIPTION
During a migration from 1.6 to 3.0 we discovered that the ability to use
symbols as tags is no longer available and raises a `TypeError: can't dup
Symbol` exception. The reason for this is that we are running each of the
tags through a block and calling `#dup` on each value without checking what
data type it is. It's a fair assumption that all values
_should_ be strings however our application has shown that this isn't the
case and we the DataDog collector handles this fine in 1.6 so I would
expect the same to be true in 3.0 unless explicitly stated otherwise.

To address the issue here I'm running each value via `#to_s` before we pass
it to `#dup` which will ensure that it never gets a symbol and chokes.

Closes #50.