### PR TITLE
Ignore nil tags and convert symbol ones

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -114,7 +114,7 @@ module Datadog
 
     def tags=(tags) #:nodoc:
       raise ArgumentError, 'tags must be a Array<String>' unless tags.nil? or tags.is_a? Array
-      @tags = (tags || []).map {|tag| escape_tag_content(tag)}
+      @tags = (tags || []).compact.map! {|tag| escape_tag_content(tag)}
     end
 
     # Sends an increment (count = 1) for the given stat to the statsd server.
@@ -358,10 +358,11 @@ module Datadog
     end
 
     def escape_tag_content(tag)
-      remove_pipes(tag).gsub COMMA, BLANK
+      remove_pipes(tag.to_s).gsub COMMA, BLANK
     end
 
     def escape_tag_content!(tag)
+      tag = tag.to_s
       tag.gsub!(PIPE, BLANK)
       tag.gsub!(COMMA, BLANK)
       tag

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -79,6 +79,22 @@ describe Datadog::Statsd do
     it 'should reject non-array tags' do
       lambda { @statsd.tags = 'tsdfs' }.must_raise ArgumentError
     end
+
+    it 'ignore nil tags' do
+      @statsd.tags = ['tag1', nil, 'tag2']
+      @statsd.tags.must_equal %w[tag1 tag2]
+    end
+
+    it 'converts symbols to strings' do
+      @statsd.tags = [:tag1, :tag2]
+      @statsd.tags.must_equal %w[tag1 tag2]
+    end
+
+    it 'assigns regular tags' do
+      tags = %w[tag1 tag2]
+      @statsd.tags = tags
+      @statsd.tags.must_equal tags
+    end
   end
 
   describe "#increment" do


### PR DESCRIPTION
@degemer 

When upgrading to version 3.0, we got a couple errors. In previous versions (at least v1), you could pass nil tags that would be ignored and symbol tags that would be converted to strings.

This brings the functionality back.