### PR TITLE
Use defaults when host/port are nil

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -95,7 +95,7 @@ module Datadog
       self.host, self.port = host, port
       @socket_path = opts[:socket_path]
       @prefix = nil
-      @socket = connect_to_socket(host, port, socket_path) if @socket_path.nil?
+      @socket = connect_to_socket(socket_path) if @socket_path.nil?
       self.namespace = opts[:namespace]
       self.tags = opts[:tags]
       @buffer = Array.new
@@ -443,13 +443,13 @@ module Datadog
       @buffer = Array.new
     end
 
-    def connect_to_socket(host, port, socket_path)
+    def connect_to_socket(socket_path)
       if !socket_path.nil?
         socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
         socket.connect(Socket.pack_sockaddr_un(socket_path))
       else
         socket = UDPSocket.new
-        socket.connect(host, port)
+        socket.connect(@host, @port)
       end
       socket
     end
@@ -476,7 +476,7 @@ module Datadog
       if retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
         retries += 1
         begin
-          @socket = connect_to_socket(host, port, socket_path)
+          @socket = connect_to_socket(socket_path)
           retry
         rescue => e
           boom = e

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -95,7 +95,7 @@ module Datadog
       self.host, self.port = host, port
       @socket_path = opts[:socket_path]
       @prefix = nil
-      @socket = connect_to_socket(socket_path) if @socket_path.nil?
+      @socket = connect_to_socket if @socket_path.nil?
       self.namespace = opts[:namespace]
       self.tags = opts[:tags]
       @buffer = Array.new
@@ -443,10 +443,10 @@ module Datadog
       @buffer = Array.new
     end
 
-    def connect_to_socket(socket_path)
-      if !socket_path.nil?
+    def connect_to_socket
+      if !@socket_path.nil?
         socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
-        socket.connect(Socket.pack_sockaddr_un(socket_path))
+        socket.connect(Socket.pack_sockaddr_un(@socket_path))
       else
         socket = UDPSocket.new
         socket.connect(@host, @port)
@@ -455,7 +455,7 @@ module Datadog
     end
 
     def sock
-      @socket ||= connect_to_socket(host, port, socket_path)
+      @socket ||= connect_to_socket
     end
 
     def send_to_socket(message)
@@ -476,7 +476,7 @@ module Datadog
       if retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
         retries += 1
         begin
-          @socket = connect_to_socket(socket_path)
+          @socket = connect_to_socket
           retry
         rescue => e
           boom = e

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -609,7 +609,7 @@ describe Datadog::Statsd do
 
     it "should not send anything when the buffer is empty" do
       @statsd.batch { }
-      @statsd.socket.recv.must_equal nil
+      assert_nil @statsd.socket.recv
     end
 
       it "should allow to send single sample in one packet" do


### PR DESCRIPTION
As we used to do it, was broken by 3.0.

See https://github.com/DataDog/dogstatsd-ruby/issues/54