### PR TITLE
Don't send anything when the buffer is empty

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -433,6 +433,7 @@ module Datadog
     end
 
     def flush_buffer()
+      return @buffer if @buffer.empty?
       send_to_socket(@buffer.join(NEW_LINE))
       @buffer = Array.new
     end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -463,6 +463,11 @@ describe Datadog::Statsd do
 
   describe "batched" do
 
+    it "should not send anything when the buffer is empty" do
+      @statsd.batch { }
+      @statsd.socket.recv.must_equal nil
+    end
+
       it "should allow to send single sample in one packet" do
         @statsd.batch do |s|
             s.increment("mycounter")


### PR DESCRIPTION
There's no need to send an empty message over the socket.