### PR TITLE
Add unix socket support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ rvm:
   - 2.4
   - jruby-19mode
 
-script: bundle exec rake
 bundler_args: --without=localdev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ rvm:
   - 2.4
   - jruby-19mode
 
+script: bundle exec rake
 bundler_args: --without=localdev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
-  - jruby-19mode
 
 bundler_args: --without=localdev

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,8 @@ task :default => :spec
 
 Rake::TestTask.new(:spec) do |spec|
   spec.libs << 'lib' << 'spec'
-  spec.pattern = 'spec/**/*_spec.rb'
+  spec.loader = :direct
+  spec.pattern = './spec/statsd_spec.rb'
   spec.verbose = true
 end
 

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -453,7 +453,11 @@ module Datadog
 
     def send_to_socket(message)
       self.class.logger.debug { "Statsd: #{message}" } if self.class.logger
-      @socket.send(message, 0)
+      if @socket_path.nil?
+        @socket.send(message, 0)
+      else
+        @socket.sendmsg_nonblock(message)
+      end
     rescue => boom
       # Try once to reconnect if the socket has been closed
       retries ||= 1


### PR DESCRIPTION
Continuation of https://github.com/DataDog/dogstatsd-ruby/pull/55
To test it locally i installed the new datadog agent to my Mac following [the instructions here](https://github.com/DataDog/datadog-agent) then used a simple ruby script like this:
```ruby
require './lib/datadog/statsd'
require 'time'
STDOUT.sync = true

socket_file = ENV['DD_DOGSTATSD_SOCKET'] || '/tmp/socket/statsd.socket'
puts "========> socket_file: #{socket_file}"

client = Datadog::Statsd.new(nil, nil, socket_path: socket_file)

loop do
  client.increment('whatever')
  sleep(1)
end
```
I tried all scenarios listed in the [testing guide](https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support#testing-methodology) and it worked.