### PR TITLE
Use assert_raises instead of expect to fix tests with 2.1.10

### DIFF
--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -242,9 +242,9 @@ describe Datadog::Statsd do
     end
 
     it "should reraise the error if block is failing" do
-      expect do
+      assert_raises StandardError do
         @statsd.time('foobar') { raise StandardError, 'This is failing' }
-      end.must_raise StandardError
+      end
     end
 
     describe "with a sample rate" do


### PR DESCRIPTION
Tests are not passing anymore on version 2.1 (now 2.1.10).
Using `assert_raises` instead of `expect` to fix the issue and keep the matrix green.