### PR TITLE
Set buffer size in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.0.0 / 0000.00.00
+
+* [BUGFIX] Make sure the UDP message fits into the 8k buffer of dd-agent. [#65][], [@Antti][]
+### Breaking changes
+max_buffer_size option now controls buffer size in bytes instead of a number of messages
+
 ## 3.3.0 / 2018.02.04
 
  * [FEATURE] Add distribution support (beta). See [#72][].

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -52,7 +52,7 @@ module Datadog
     DISTRIBUTION_TYPE = 'd'.freeze
     TIMING_TYPE = 'ms'.freeze
     SET_TYPE = 's'.freeze
-    VERSION = "3.3.0".freeze
+    VERSION = "4.0.0".freeze
 
     # A namespace to prepend to all statsd calls. Defaults to no namespace.
     attr_reader :namespace

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -712,18 +712,15 @@ describe Datadog::Statsd do
     end
 
     it "should flush when the buffer gets too big" do
+      expected_message = 'mycounter:1|c'
+      number_of_messages_to_fill_the_buffer = (8192 - 1) / (expected_message.bytesize + 1)
       @statsd.batch do |s|
-        # increment a counter 50 times in batch
-        51.times do
+        # increment a counter to fill the buffer and trigger buffer flush
+        (number_of_messages_to_fill_the_buffer + 1).times do
           s.increment("mycounter")
         end
 
-        # We should receive a packet of 50 messages that was automatically
-        # flushed when the buffer got too big
-        theoretical_reply = Array.new
-        50.times do
-          theoretical_reply.push('mycounter:1|c')
-        end
+        theoretical_reply = Array.new(number_of_messages_to_fill_the_buffer) { 'mycounter:1|c' }
         @statsd.socket.recv.must_equal [theoretical_reply.join("\n")]
       end
 


### PR DESCRIPTION
### Set max_buffer_size in bytes

dd-agent read buffer size is set to [8192 bytes by default](https://github.com/DataDog/dd-agent/blob/425de487204bfe7aefdd72e5895a33db90ee6f1a/dogstatsd.py#L367).

The statsd protocol doesn't send the expected message size along with the message, so the dd-agent can not know if the whole message was read or not, it expects full message to fit into the read buffer.
If the message exceeds the buffer size, it will get truncated and parsed incorrectly. 

Therefore the whole message must fit into the dd-agent read buffer.
Currently, `max_buffer_size` indicates a number of messages buffer holds before it gets flushed. This is an arbitrary number, which does not allow us to efficiently buffer in most of the cases:
* There are many small messages, and buffer will be flushed too often (not a huge problem)
* There is a number of large messages, where buffer will be flushed too late, and will overfill the read buffer of dd-agent, resulting in the messages truncation and corruption

This PR changes the meaning of `max_buffer_size` to represent number of bytes to be sent, rather than a number of messages. The default value (8192) matches the dd-agent default buffer size.