### PR TITLE
Add statsd sample rate compat

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -126,6 +126,7 @@ module Datadog
     # @option opts [Numeric] :by increment value, default 1
     # @see #count
     def increment(stat, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       incr_value = opts.fetch(:by, 1)
       count stat, incr_value, opts
     end
@@ -139,6 +140,7 @@ module Datadog
     # @option opts [Numeric] :by decrement value, default 1
     # @see #count
     def decrement(stat, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       decr_value = - opts.fetch(:by, 1)
       count stat, decr_value, opts
     end
@@ -151,6 +153,7 @@ module Datadog
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
     # @option opts [Array<String>] :tags An array of tags
     def count(stat, count, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       send_stats stat, count, COUNTER_TYPE, opts
     end
 
@@ -168,6 +171,7 @@ module Datadog
     # @example Report the current user count:
     #   $statsd.gauge('user.count', User.count)
     def gauge(stat, value, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       send_stats stat, value, GAUGE_TYPE, opts
     end
 
@@ -195,6 +199,7 @@ module Datadog
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
     # @option opts [Array<String>] :tags An array of tags
     def timing(stat, ms, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       send_stats stat, ms, TIMING_TYPE, opts
     end
 
@@ -212,6 +217,7 @@ module Datadog
     # @example Report the time (in ms) taken to activate an account
     #   $statsd.time('account.activate') { @account.activate! }
     def time(stat, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       start = Time.now
       return yield
     ensure
@@ -227,6 +233,7 @@ module Datadog
     # @example Record a unique visitory by id:
     #   $statsd.set('visitors.uniques', User.id)
     def set(stat, value, opts={})
+      opts = {:sample_rate => opts} if opts.is_a? Numeric
       send_stats stat, value, SET_TYPE, opts
     end
 


### PR DESCRIPTION
[statsd-ruby](https://github.com/reinh/statsd/blob/4c11cc48ca02032401d59ac105e75e343b1e4130/lib/statsd.rb#L337) takes a simple numeric argument for sample rate:

```ruby
  # Sends an increment (count = 1) for the given stat to the statsd server.
  #
  # @param [String] stat stat name
  # @param [Numeric] sample_rate sample rate, 1 for always
  # @see #count
  def increment(stat, sample_rate=1)
    count stat, 1, sample_rate
  end
```

The [datadog statsd version](https://github.com/DataDog/dogstatsd-ruby/blob/master/lib/datadog/statsd.rb#L120-L131) only takes sample rate as a keyword option:

```ruby
    # Sends an increment (count = 1) for the given stat to the statsd server.
    #
    # @param [String] stat stat name
    # @param [Hash] opts the options to create the metric with
    # @option opts [Numeric] :sample_rate sample rate, 1 for always
    # @option opts [Array<String>] :tags An array of tags
    # @option opts [Numeric] :by increment value, default 1
    # @see #count
    def increment(stat, opts={})
      incr_value = opts.fetch(:by, 1)
      count stat, incr_value, opts
    end
```

The datadog statsd instance doesn't quite provide drop-in compatibility given this argument. We're using a Datadog Statsd instance as a Statsd instance to pass into a third party gem and it uses this argument. Adding compatibility here seems reasonable?

Thanks!