### PR TITLE
use faster time method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ group :localdev do
 end
 
 group :test do
-  gem "timecop"
   gem 'tins', '~> 1.6.0'
+  gem 'mocha'
   if RbConfig::CONFIG['ruby_version'].start_with?("1.9")
     gem 'json', '< 2'
     gem 'public_suffix', '< 1.5'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,10 +1,8 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'faker'
 
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
... also makes the method more symmetric

pro: faster
con: not stubbed by timecop and not available on ruby <2.1

... let me know what you think, I can fix up the specs if you want the PR