### PR TITLE
reduce object allocation and make all strings frozen on ruby 2.3+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,12 @@ gem 'minitest'
 gem "yard", "~> 0.8.7.3"
 gem 'single_cov'
 
-unless RUBY_VERSION.start_with?("1.9")
-  gem 'rubocop', "~> 0.49.0", platform: :ruby_25 # bump this and TargetRubyVersion once we drop ruby 1.9
+if RUBY_VERSION >= "2.0.0"
+  gem 'rubocop', "~> 0.49.0" # bump this and TargetRubyVersion once we drop ruby 1.9
+end
+
+if RUBY_VERSION >= "2.3.0"
+  gem 'allocation_stats'
 end
 
 group :development do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,6 +6,7 @@ if RUBY_VERSION > "2.0"
 end
 
 require 'minitest/autorun'
+require 'mocha/mini_test'
 require 'faker'
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)


### PR DESCRIPTION
this is slightly more dangerous on ruby 2.3+ since it makes all internal strings frozen ... and they might blow up in untested edge-cases, so maybe get 3.3 out and leave it  for 3.4 ...

as a bonus feature this also makes sure we never modify options hash that is passed in

@masci 

Failing test will look like this:
<img width="1307" alt="screen shot 2018-02-03 at 3 19 48 pm" src="https://user-images.githubusercontent.com/11367/35773841-0eefe8fe-0913-11e8-80a9-ac92f0dc5c30.png">
