### PR TITLE
improve code coverage / make format_event private

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -46,6 +46,8 @@ module Datadog
     CRITICAL  = 2
     UNKNOWN   = 3
 
+    MAX_EVENT_SIZE = 8 * 1024
+
     COUNTER_TYPE = 'c'.freeze
     GAUGE_TYPE = 'g'.freeze
     HISTOGRAM_TYPE = 'h'.freeze
@@ -314,10 +316,7 @@ module Datadog
     # @example Report an awful event:
     #   $statsd.event('Something terrible happened', 'The end is near if we do nothing', :alert_type=>'warning', :tags=>['end_of_times','urgent'])
     def event(title, text, opts={})
-      event_string = format_event(title, text, opts)
-      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string.length > 8 * 1024
-
-      send_to_socket event_string
+      send_to_socket format_event(title, text, opts)
     end
 
     # Send several metrics in the same UDP Packet
@@ -355,8 +354,8 @@ module Datadog
         event_string_data << "|##{tags_string}"
       end
 
-      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > 8192 # 8 * 1024 = 8192
-      return event_string_data
+      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > MAX_EVENT_SIZE
+      event_string_data
     end
 
     # Close the underlying socket

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -327,13 +327,32 @@ module Datadog
     #      s.gauge('users.online',156)
     #      s.increment('page.views')
     #    end
-    def batch()
+    def batch
       @batch_nesting_depth += 1
       yield self
     ensure
       @batch_nesting_depth -= 1
       flush_buffer if @batch_nesting_depth == 0
     end
+
+    # Close the underlying socket
+    def close
+      @socket.close
+    end
+
+    private
+
+    NEW_LINE = "\n".freeze
+    ESC_NEW_LINE = "\\n".freeze
+    COMMA = ",".freeze
+    PIPE = "|".freeze
+    DOT = ".".freeze
+    DOUBLE_COLON = "::".freeze
+    UNDERSCORE = "_".freeze
+    PROCESS_TIME_SUPPORTED = (RUBY_VERSION >= "2.1.0")
+
+    private_constant :NEW_LINE, :ESC_NEW_LINE, :COMMA, :PIPE, :DOT,
+      :DOUBLE_COLON, :UNDERSCORE
 
     def format_event(title, text, opts={})
       escaped_title = escape_event_content(title)
@@ -357,25 +376,6 @@ module Datadog
       raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > MAX_EVENT_SIZE
       event_string_data
     end
-
-    # Close the underlying socket
-    def close()
-      @socket.close
-    end
-
-    private
-
-    NEW_LINE = "\n".freeze
-    ESC_NEW_LINE = "\\n".freeze
-    COMMA = ",".freeze
-    PIPE = "|".freeze
-    DOT = ".".freeze
-    DOUBLE_COLON = "::".freeze
-    UNDERSCORE = "_".freeze
-    PROCESS_TIME_SUPPORTED = (RUBY_VERSION >= "2.1.0")
-
-    private_constant :NEW_LINE, :ESC_NEW_LINE, :COMMA, :PIPE, :DOT,
-      :DOUBLE_COLON, :UNDERSCORE
 
     def tags_as_string(opts)
       tag_arr = opts[:tags] || []

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -774,13 +774,13 @@ describe Datadog::Statsd do
 
       it "Only title and text" do
         @statsd.event(title, text)
-        @statsd.socket.recv.must_equal [@statsd.format_event(title, text)]
+        @statsd.socket.recv.must_equal [@statsd.send(:format_event, title, text)]
       end
       it "With line break in Text and title" do
         title_break_line = "#{title} \n second line"
         text_break_line = "#{text} \n second line"
         @statsd.event(title_break_line, text_break_line)
-        @statsd.socket.recv.must_equal [@statsd.format_event(title_break_line, text_break_line)]
+        @statsd.socket.recv.must_equal [@statsd.send(:format_event, title_break_line, text_break_line)]
       end
       it "Event data string too long > 8KB" do
         long_text = "#{text} " * 200000
@@ -788,45 +788,45 @@ describe Datadog::Statsd do
       end
       it "With known alert_type" do
         @statsd.event(title, text, :alert_type => 'warning')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|t:warning"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|t:warning"]
       end
       it "With unknown alert_type" do
         @statsd.event(title, text, :alert_type => 'bizarre')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|t:bizarre"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|t:bizarre"]
       end
       it "With known priority" do
         @statsd.event(title, text, :priority => 'low')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|p:low"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|p:low"]
       end
       it "With unknown priority" do
         @statsd.event(title, text, :priority => 'bizarre')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|p:bizarre"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|p:bizarre"]
       end
       it "With hostname" do
         @statsd.event(title, text, :hostname => 'hostname_test')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|h:hostname_test"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|h:hostname_test"]
       end
       it "With aggregation_key" do
         @statsd.event(title, text, :aggregation_key => 'aggkey 1')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|k:aggkey 1"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|k:aggkey 1"]
       end
       it "With source_type_name" do
         @statsd.event(title, text, :source_type_name => 'source 1')
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|s:source 1"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|s:source 1"]
       end
       it "With several tags" do
         @statsd.event(title, text, :tags => tags)
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text)}|##{tags_joined}"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|##{tags_joined}"]
       end
       it "Takes into account the common tags" do
-        basic_result = @statsd.format_event(title, text)
+        basic_result = @statsd.send(:format_event, title, text)
         common_tag = 'common'
         @statsd.instance_variable_set :@tags, [common_tag]
         @statsd.event(title, text)
         @statsd.socket.recv.must_equal ["#{basic_result}|##{common_tag}"]
       end
       it "combines common and specific tags" do
-        basic_result = @statsd.format_event(title, text)
+        basic_result = @statsd.send(:format_event, title, text)
         common_tag = 'common'
         @statsd.instance_variable_set :@tags, [common_tag]
         @statsd.event(title, text, :tags => tags)
@@ -840,7 +840,7 @@ describe Datadog::Statsd do
           :hostname => 'hostname_test',
           :tags => tags
         }
-        @statsd.socket.recv.must_equal ["#{@statsd.format_event(title, text, opts)}"]
+        @statsd.socket.recv.must_equal ["#{@statsd.send(:format_event, title, text, opts)}"]
       end
     end
   end


### PR DESCRIPTION
format_event was meant to be a private testing helper in https://github.com/DataDog/dogstatsd-ruby/commit/d8862aacba7d8ec0c92b8f9ba38022ea0b4b2d00

@masci 