### PR TITLE
Set buffer size in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
  * port / host / tags / namespace can no longer be set on the instance to allow thread-safety [#87][] by [@grosser][] 
  * replace global logger with instance option [#90][] by [@grosser][] 
  * make format_service_check private [#89][] [@grosser][] 
+ * [IMPROVEMENT] Frozen strings and less allocations everywhere. [#78][], [@grosser][]
+ * [BUGFIX] Make sure the UDP message fits into the 8k buffer of dd-agent. [#86][], [@Antti][]
+ * max_buffer_size initializer argument removed and replaced with max_buffer_bytes (defaults to 8192)
+ * max_buffer_size/max_buffer_size= methods removed
+ * format_event is now private
 
 ## 3.3.0 / 2018.02.04
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -683,18 +683,15 @@ describe Datadog::Statsd do
     end
 
     it "should flush when the buffer gets too big" do
+      expected_message = 'mycounter:1|c'
+      number_of_messages_to_fill_the_buffer = (8192 - 1) / (expected_message.bytesize + 1)
       @statsd.batch do |s|
-        # increment a counter 50 times in batch
-        51.times do
+        # increment a counter to fill the buffer and trigger buffer flush
+        (number_of_messages_to_fill_the_buffer + 1).times do
           s.increment("mycounter")
         end
 
-        # We should receive a packet of 50 messages that was automatically
-        # flushed when the buffer got too big
-        theoretical_reply = Array.new
-        50.times do
-          theoretical_reply.push('mycounter:1|c')
-        end
+        theoretical_reply = Array.new(number_of_messages_to_fill_the_buffer) { 'mycounter:1|c' }
         @statsd.socket.recv.must_equal [theoretical_reply.join("\n")]
       end
 


### PR DESCRIPTION
Default buffer size matches dd-agent read buffer

@Antti @jonmoter 

as replacement for https://github.com/DataDog/dogstatsd-ruby/pull/82 and https://github.com/DataDog/dogstatsd-ruby/pull/65