### PR TITLE
fail fast on unknown options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.0
 
 LineLength:
   Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "yard", "~> 0.8.7.3"
 gem 'single_cov'
 
 if RUBY_VERSION >= "2.0.0"
-  gem 'rubocop', "~> 0.49.0" # bump this and TargetRubyVersion once we drop ruby 1.9
+  gem 'rubocop', "~> 0.50.0" # bump this and TargetRubyVersion once we drop ruby 2.0
 end
 
 if RUBY_VERSION >= "2.3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'yard'
 
-task :default => :spec
+task default: [:spec, :rubocop]
 
 Rake::TestTask.new(:spec) do |spec|
   spec.loader = :direct

--- a/dogstatsd-ruby.gemspec
+++ b/dogstatsd-ruby.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.files = Dir["LICENSE.txt", "README.md", "lib/**/*.rb",]
   s.homepage = "http://github.com/datadog/dogstatsd-ruby"
   s.licenses = ["MIT"]
+  s.required_ruby_version = '>= 2.0.0'
 end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -72,6 +72,12 @@ describe Datadog::Statsd do
         Datadog::Statsd.new nil, nil, :tags => 'global'
       end
     end
+
+    it "fails on unknown options" do
+      assert_raises ArgumentError do
+        Datadog::Statsd.new nil, nil, :foo => 'bar'
+      end
+    end
   end
 
   describe "#increment" do
@@ -243,10 +249,12 @@ describe Datadog::Statsd do
       end
 
       it "should still time if block is failing" do
-        @statsd.time('foobar') do
-          stub_time 1
-          raise StandardError, 'This is failing'
-        end rescue
+        assert_raises StandardError do
+          @statsd.time('foobar') do
+            stub_time 1
+            raise StandardError, 'This is failing'
+          end
+        end
         @statsd.socket.recv.must_equal ['foobar:1000|ms']
       end
 


### PR DESCRIPTION
prevents typos and makes the initializer easier to read + less hash lookups ... might do that for more methods later

needs ruby 2.0+ ... 1.9 was "end of life" February 23, 2015 ... and whoever still runs it will get an old version since it requires 2.0+