### PR TITLE
extract connection for separation of concerns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 
+ * port / host / socket_path readers are now on statsd.connection
  * port / host / tags / namespace can no longer be set on the instance to allow thread-safety [#87][] by [@grosser][] 
  * replace global logger with instance option [#90][] by [@grosser][] 
  * make format_service_check private [#89][] [@grosser][] 


### PR DESCRIPTION
when looking into thread-safety I realized that connection related methods are sprinkled throughout Statsd ... should be cleaner to move them to a nice small class instead

could also be useful when making batch into a standalone object that can send directly to connection

@gmmeyer @johvet