### PR TITLE
add .open for short-lived reporting that does not leave sockets around

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ end
 
 # Tag a metric.
 statsd.histogram('query.time', 10, :tags => ["version:1"])
+
+# Auto-close socket after end of block
+Datadog::Statsd.open('localhost', 8125) do |s|
+  s.increment('page.views')
+end
 ```
 
 You can also post events to your stream. You can tag them, set priority and even aggregate them with other events.

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -77,7 +77,7 @@ module Datadog
 
       # Close the underlying socket
       def close
-        @socket.close
+        @socket && @socket.close
       end
 
       private
@@ -177,6 +177,15 @@ module Datadog
       @buffer = String.new
       @buffer_bytes = 0
       @batch_nesting_depth = 0
+    end
+
+    # yield a new instance to a block and close it when done
+    # for short-term use-cases that don't want to close the socket manually
+    def self.open(*args)
+      instance = new(*args)
+      yield instance
+    ensure
+      instance.close
     end
 
     # Sends an increment (count = 1) for the given stat to the statsd server.

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -81,6 +81,23 @@ describe Datadog::Statsd do
     end
   end
 
+  describe "#open" do
+    it "sends and then closes" do
+      instance = nil
+      Datadog::Statsd.open('1.2.3.4', 1234) do |s|
+        instance = s
+        s.connection.host.must_equal '1.2.3.4'
+        s.increment 'foo'
+        s.connection.expects(:close)
+      end
+      instance.class.must_equal Datadog::Statsd
+    end
+
+    it "does not fail closing when nothing was sent" do
+      Datadog::Statsd.open('1.2.3.4', 1234) {}
+    end
+  end
+
   describe "#increment" do
     it "formats the message according to the statsd spec" do
       @statsd.increment('foobar')


### PR DESCRIPTION
@gmmeyer @adammw