### PR TITLE
Display error logs if `write` fails due to a bad socket

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -33,32 +33,15 @@ module Datadog
       # DogStatsd unix socket path. Not used by default.
       attr_reader :socket_path
 
-      def initialize(host, port, socket_path, logger)
-        @host = host || DEFAULT_HOST
-        @port = port || DEFAULT_PORT
-        @socket_path = socket_path
-        @logger = logger
+      # Close the underlying socket
+      def close
+        @socket && @socket.close
       end
 
       def write(message)
         @logger.debug { "Statsd: #{message}" } if @logger
-        if @socket_path.nil?
-          socket.send(message, 0)
-        else
-          socket.sendmsg_nonblock(message)
-        end
+        send_message(message)
       rescue StandardError => boom
-        # Give up on this socket if it looks like it is bad
-        bad_socket = !@socket_path.nil? && (
-          boom.is_a?(Errno::ECONNREFUSED) ||
-          boom.is_a?(Errno::ECONNRESET) ||
-          boom.is_a?(Errno::ENOENT)
-        )
-        if bad_socket
-          @socket = nil
-          return
-        end
-
         # Try once to reconnect if the socket has been closed
         retries ||= 1
         if retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
@@ -75,26 +58,54 @@ module Datadog
         nil
       end
 
-      # Close the underlying socket
-      def close
-        @socket && @socket.close
-      end
-
       private
 
       def socket
         @socket ||= connect
       end
+    end
+
+    class UDPConnection < Connection
+      def initialize(host, port, logger)
+        @host = host || DEFAULT_HOST
+        @port = port || DEFAULT_PORT
+        @logger = logger
+      end
+
+      private
 
       def connect
-        if @socket_path.nil?
-          socket = UDPSocket.new
-          socket.connect(@host, @port)
-        else
-          socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
-          socket.connect(Socket.pack_sockaddr_un(@socket_path))
-        end
+        socket = UDPSocket.new
+        socket.connect(@host, @port)
         socket
+      end
+
+      def send_message(message)
+        socket.send(message, 0)
+      end
+    end
+
+    class UDSConnection < Connection
+      class BadSocketError < StandardError; end
+
+      def initialize(socket_path, logger)
+        @socket_path = socket_path
+        @logger = logger
+      end
+
+      private
+
+      def connect
+        socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+        socket.connect(Socket.pack_sockaddr_un(@socket_path))
+        socket
+      end
+
+      def send_message(message)
+        socket.sendmsg_nonblock(message)
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ENOENT => e
+        @socket = nil
+        raise BadSocketError, "#{e.class}: #{e}"
       end
     end
 
@@ -213,7 +224,11 @@ module Datadog
       socket_path: nil,
       logger: nil
     )
-      @connection = Connection.new(host, port, socket_path, logger)
+      if socket_path.nil?
+        @connection = UDPConnection.new(host, port, logger)
+      else
+        @connection = UDSConnection.new(socket_path, logger)
+      end
       @logger = logger
 
       @namespace = namespace


### PR DESCRIPTION
I want to display error logs so that I can notice that `write` fails, but currently no logs are displayed even if `write` fails due to a bad socket.
I confirmed the behavior using the following script:


```ruby
require 'logger'
require 'socket'
require 'datadog/statsd'

socket_path = '/tmp/datadog/dsd.socket'
Thread.new do
  2.times do
    sock = Socket.new(:UNIX, :DGRAM, 0)
    sock.bind(Addrinfo.unix(socket_path))

    3.times do
      puts "Received: #{sock.recvfrom_nonblock(128).first}"
    rescue IO::WaitReadable
      sleep 0.1
      retry
    end
    puts "Close socket"
    sock.close
    File.unlink(socket_path)
    sleep 2
  end
end

logger = Logger.new($stdout)
logger.level = Logger::INFO
statsd = Datadog::Statsd.new(nil, nil, socket_path: socket_path, logger: logger)
while true
  print 'increment: '
  p statsd.increment("page.views")
  sleep 1
end
```



## Before

```
$ ruby /path/to/script
increment: 14
Received: page.views:1|c
increment: 14
Received: page.views:1|c
increment: 14
Received: page.views:1|c
Close socket
increment: nil
increment: nil
increment: 14
Received: page.views:1|c
```

## After

```
$ ruby /path/to/script
increment: 14
Received: page.views:1|c
increment: 14
Received: page.views:1|c
increment: 14
Received: page.views:1|c
Close socket
increment: E, [2018-07-30T18:58:03.582215 #41583] ERROR -- : Statsd: Datadog::Statsd::UDSConnection::BadSocketError Errno::ECONNRESET: Connection reset by peer - sendmsg(2)
nil
increment: E, [2018-07-30T18:58:04.583728 #41583] ERROR -- : Statsd: Datadog::Statsd::UDSConnection::BadSocketError Errno::ENOENT: No such file or directory - connect(2) for /tmp/datadog/dsd.socket
nil
increment: 14
Received: page.views:1|c
```