### PR TITLE
Handle ENOTCONN

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -62,7 +62,8 @@ module Datadog
 
         # Try once to reconnect if the socket has been closed
         retries ||= 1
-        if retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
+        if retries <= 1 && boom.is_a?(Errno::ENOTCONN) or
+           retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
           retries += 1
           begin
             @socket = connect

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -52,6 +52,7 @@ module Datadog
         bad_socket = !@socket_path.nil? && (
           boom.is_a?(Errno::ECONNREFUSED) ||
           boom.is_a?(Errno::ECONNRESET) ||
+          boom.is_a?(Errno::ENOTCONN) ||
           boom.is_a?(Errno::ENOENT)
         )
         if bad_socket


### PR DESCRIPTION
Unset socket under the condition ENOTCONN this could happen in the event the datadog agent is restarted and using a unix socket file.

- Unset socket in the condition a connection is lost
- Added test to handle ENOTCONN