### PR TITLE
Retry first before losing message when receiving ENOTCONN

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -52,7 +52,6 @@ module Datadog
         bad_socket = !@socket_path.nil? && (
           boom.is_a?(Errno::ECONNREFUSED) ||
           boom.is_a?(Errno::ECONNRESET) ||
-          boom.is_a?(Errno::ENOTCONN) ||
           boom.is_a?(Errno::ENOENT)
         )
         if bad_socket


### PR DESCRIPTION
I made another contribution in the context of the ENOTCONN error coming from our applications when we restart the Datadog agent. This new version attempts to retry before dropping a message.