### PR TITLE
Format event's text @param

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -396,7 +396,7 @@ module Datadog
     # it will be grouped with other events that don't have an event type.
     #
     # @param [String] title Event title
-    # @param [String] text Event text. Supports \n
+    # @param [String] text Event text. Supports newlines (+\n+)
     # @param [Hash] opts the additional data about the event
     # @option opts [Integer, nil] :date_happened (nil) Assign a timestamp to the event. Default is now when none
     # @option opts [String, nil] :hostname (nil) Assign a hostname to the event.


### PR DESCRIPTION
As is, it renders as `n`, which made me think it was cut off midline.
This uses the word `newlines` and also uses the preformatted rdoc syntax
to make the newline character preformatted


See https://www.rubydoc.info/github/DataDog/dogstatsd-ruby/master/Datadog/Statsd#event-instance_method :

![](https://cl.ly/3fdd31dc9d58/Image%202019-01-28%20at%203.33.12%20PM.png)