### PR TITLE
Allow tags as hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ end
 # Tag a metric.
 statsd.histogram('query.time', 10, :tags => ["version:1"])
 
+# Tag a metric by passing in a Hash
+statsd.histogram('query.time', 10, :tags => {version: 1})
+
 # Auto-close socket after end of block
 Datadog::Statsd.open('localhost', 8125) do |s|
   s.increment('page.views')

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -202,8 +202,8 @@ module Datadog
     # @param [String] host your statsd host
     # @param [Integer] port your statsd port
     # @option [String] namespace set a namespace to be prepended to every metric name
-    # @option [Array<String>] tags tags to be added to every metric
-    # @option [Loger] logger for debugging
+    # @option [Array<String>|Hash] tags tags to be added to every metric
+    # @option [Logger] logger for debugging
     # @option [Integer] max_buffer_bytes max bytes to buffer when using #batch
     # @option [String] socket_path unix socket path
     def initialize(
@@ -221,7 +221,11 @@ module Datadog
       @namespace = namespace
       @prefix = @namespace ? "#{@namespace}.".freeze : nil
 
-      raise ArgumentError, 'tags must be a Array<String>' unless tags.nil? or tags.is_a? Array
+      unless tags.nil? or tags.is_a? Array or tags.is_a? Hash
+        raise ArgumentError, 'tags must be a Array<String> or a Hash'
+      end
+
+      tags = tag_hash_to_array(tags) if tags.is_a? Hash
       @tags = (tags || []).compact.map! {|tag| escape_tag_content(tag)}
 
       @batch = Batch.new @connection, max_buffer_bytes
@@ -490,12 +494,17 @@ module Datadog
 
     def tags_as_string(opts)
       if tag_arr = opts[:tags]
+        tag_arr = tag_hash_to_array(tag_arr) if tag_arr.is_a? Hash
         tag_arr = tag_arr.map { |tag| escape_tag_content(tag) }
         tag_arr = tags + tag_arr # @tags are normalized when set, so not need to normalize them again
       else
         tag_arr = tags
       end
       tag_arr.join(COMMA) unless tag_arr.empty?
+    end
+
+    def tag_hash_to_array(tag_hash)
+      tag_hash.to_a.map {|pair| pair.compact.join(":")}
     end
 
     def escape_event_content(msg)


### PR DESCRIPTION
I wanted the internal API to be more friendly to the Ruby "principle of least surprise." I'd like to be able to pass a hash to `:tags` when measuring things, instead of an array of strings delimited by a colon.

This change allows a user to pass tags into the `.new()` method as well as individual measurement methods.

I created specs that test the outside interfaces, but I didn't add any for the internal, private method I created. I can create a couple of unit tests for that method if you'd like.