### PR TITLE
add env vars support for dogstatsd host, port and entity id

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -34,8 +34,8 @@ module Datadog
       attr_reader :socket_path
 
       def initialize(host, port, socket_path, logger)
-        @host = host || DEFAULT_HOST
-        @port = port || DEFAULT_PORT
+        @host = host || ENV.fetch('DD_AGENT_HOST', nil) || DEFAULT_HOST
+        @port = port || ENV.fetch('DD_DOGSTATSD_PORT', nil) || DEFAULT_PORT
         @socket_path = socket_path
         @logger = logger
       end
@@ -222,6 +222,9 @@ module Datadog
 
       raise ArgumentError, 'tags must be a Array<String>' unless tags.nil? or tags.is_a? Array
       @tags = (tags || []).compact.map! {|tag| escape_tag_content(tag)}
+
+      # append the entity id to tags if DD_ENTITY_ID env var is not nil
+      @tags << 'dd.internal.entity_id:' + ENV.fetch('DD_ENTITY_ID', nil) unless ENV.fetch('DD_ENTITY_ID', nil).nil?
 
       @batch = Batch.new @connection, max_buffer_bytes
     end

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -224,7 +224,7 @@ module Datadog
       @tags = (tags || []).compact.map! {|tag| escape_tag_content(tag)}
 
       # append the entity id to tags if DD_ENTITY_ID env var is not nil
-      @tags << 'dd.internal.entity_id:' + ENV.fetch('DD_ENTITY_ID', nil) unless ENV.fetch('DD_ENTITY_ID', nil).nil?
+      @tags << 'dd.internal.entity_id:' + escape_tag_content(ENV.fetch('DD_ENTITY_ID', nil)) unless ENV.fetch('DD_ENTITY_ID', nil).nil?
 
       @batch = Batch.new @connection, max_buffer_bytes
     end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -96,7 +96,7 @@ describe Datadog::Statsd do
       stub = Proc.new do |arg|
         arg == 'DD_ENTITY_ID' ? '04652bb7-19b7-11e9-9cc6-42010a9c016d' : nil
       end
-        ENV.stub :fetch, stub do
+      ENV.stub :fetch, stub do
         statsd = Datadog::Statsd.new '1.3.3.7', 8126, :tags => %w(global), :namespace => 'space'
         statsd.connection.host.must_equal '1.3.3.7'
         statsd.connection.port.must_equal 8126

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -32,6 +32,17 @@ describe Datadog::Statsd do
       @statsd.connection.port.must_equal 1234
     end
 
+    it "uses env vars host and port when nil is given" do
+      stub = Proc.new do |arg|
+        arg == 'DD_AGENT_HOST' ? 'myhost' : '1234'
+      end
+      ENV.stub :fetch, stub do
+        @statsd = Datadog::Statsd.new(nil, nil, {})
+        @statsd.connection.host.must_equal 'myhost'
+        @statsd.connection.port.must_equal '1234'
+      end
+    end
+
     it "uses default host and port when nil is given to allow only passing options" do
       @statsd = Datadog::Statsd.new(nil, nil, {})
       @statsd.connection.host.must_equal '127.0.0.1'
@@ -59,6 +70,19 @@ describe Datadog::Statsd do
       statsd.tags.must_equal []
     end
 
+    it "defaults host, port, namespace, and tags contains entity id" do
+      stub = Proc.new do |arg|
+        arg == 'DD_ENTITY_ID' ? '04652bb7-19b7-11e9-9cc6-42010a9c016d' : nil
+      end
+      ENV.stub :fetch, stub do
+        statsd = Datadog::Statsd.new
+        statsd.connection.host.must_equal '127.0.0.1'
+        statsd.connection.port.must_equal 8125
+        assert_nil statsd.namespace
+        statsd.tags.must_equal ['dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']
+      end
+    end
+
     it 'sets host, port, namespace, and tags' do
       statsd = Datadog::Statsd.new '1.3.3.7', 8126, :tags => %w(global), :namespace => 'space'
       statsd.connection.host.must_equal '1.3.3.7'
@@ -66,6 +90,20 @@ describe Datadog::Statsd do
       statsd.namespace.must_equal 'space'
       statsd.instance_variable_get('@prefix').must_equal 'space.'
       statsd.tags.must_equal ['global']
+    end
+
+    it 'sets host, port, namespace, and tags and get entity id from inv var' do
+      stub = Proc.new do |arg|
+        arg == 'DD_ENTITY_ID' ? '04652bb7-19b7-11e9-9cc6-42010a9c016d' : nil
+      end
+        ENV.stub :fetch, stub do
+        statsd = Datadog::Statsd.new '1.3.3.7', 8126, :tags => %w(global), :namespace => 'space'
+        statsd.connection.host.must_equal '1.3.3.7'
+        statsd.connection.port.must_equal 8126
+        statsd.namespace.must_equal 'space'
+        statsd.instance_variable_get('@prefix').must_equal 'space.'
+        statsd.tags.must_equal ['global', 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']
+      end
     end
 
     it 'fails on invalid tags' do


### PR DESCRIPTION
Add environment variables support for Client configuration

Support of 3 environment variables for Client configuration:

`"DD_AGENT_HOST"` used to provide the Agent hostname.
`"DD_DOGSTATSD_PORT"` used to provide the DogStatsD port.
`"DD_ENTITY_ID"` used to provide an identifier to the Client.


If Client constructor's arguments are not set, prioritize `"DD_AGENT_HOST"` and `"DD_DOGSTATSD_PORT"` over default values.
Add `"DD_ENTITY_ID"` to tags with the tag name `dd.internal.entity_id`.