### PR TITLE
Default sample rate

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -520,7 +520,7 @@ module Datadog
 
     def send_stats(stat, delta, type, opts=EMPTY_OPTIONS)
       sample_rate = opts[:sample_rate] || 1
-      if sample_rate == 1 or rand < sample_rate
+      if sample_rate == 1 or rand <= sample_rate
         full_stat = ''.dup
         full_stat << @prefix if @prefix
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -393,7 +393,7 @@ describe Datadog::Statsd do
     end
 
     describe "when the sample rate is equal to a random value [0,1]" do
-      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      before { class << @statsd; def rand; 0.5; end; end } # ensure delivery
       it "should send" do
         @statsd.timing('foobar', 500, :sample_rate=>0.5)
         socket.recv.must_equal ['foobar:500|ms|@0.5']


### PR DESCRIPTION
This adds a flag to the constructor to allow setting a default sample rate, if the caller doesn't set one on each call.  This also fixes a minor problem in the sampling test cases and a bug with the sampling edge case that it was hiding.