### PR TITLE
origin detection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ statsd.event(
 
 
 
+Origin detection over UDP
+-------------
+Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
+
+To enable origin detection over UDP, add the following lines to your application manifest
+```yaml
+env:
+  - name: DD_ENTITY_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+```
+The DogStatsD client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable, which is the pod’s UID.
+
+
 Documentation
 -------------
 


### PR DESCRIPTION
Document the origin detection feature introduced by https://github.com/DataDog/dogstatsd-ruby/pull/109  with an example of how to set up the `DD_ENTITY_ID` env var.