### PR TITLE
Use String#bytesize instead of String#length in #format_event

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -470,7 +470,7 @@ module Datadog
     def format_event(title, text, opts=EMPTY_OPTIONS)
       escaped_title = escape_event_content(title)
       escaped_text = escape_event_content(text)
-      event_string_data = "_e{#{escaped_title.length},#{escaped_text.length}}:#{escaped_title}|#{escaped_text}".dup
+      event_string_data = "_e{#{escaped_title.bytesize},#{escaped_text.bytesize}}:#{escaped_title}|#{escaped_text}".dup
 
       # We construct the string to be sent by adding '|key:value' parts to it when needed
       # All pipes ('|') in the metadata are removed. Title and Text can keep theirs
@@ -486,7 +486,7 @@ module Datadog
         event_string_data << "|##{tags_string}"
       end
 
-      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.length > MAX_EVENT_SIZE
+      raise "Event #{title} payload is too big (more that 8KB), event discarded" if event_string_data.bytesize > MAX_EVENT_SIZE
       event_string_data
     end
 


### PR DESCRIPTION
I found some issues which cause texts truncated on Datadog Event Stream when there are some characters outside ASCII range.

For example, a Korean letter(Hangul) takes 3 bytes in UTF-8 but current implementation considers it taking a byte. so every time a Korean letters there will be two bytes truncated. 

```ruby
text = "한글 한 자당 세 바이트abcdefghijklmnopqr"
text.length # => 31
text.bytesize # => 49

# remaining 18 bytes will be ignored in dd-agent (or datadog)
Datadog.dogstatsd.event("info", text, tags: ["test"], alert_type: "info")
```

Replacing `String#length` with [`String#bytesize`](https://www.rubydoc.info/stdlib/core/String:bytesize) would fix this issue.