### PR TITLE
Handle ECONNREFUSED and typo fix

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -44,9 +44,10 @@ module Datadog
       rescue StandardError => boom
         # Try once to reconnect if the socket has been closed
         retries ||= 1
-        if retries <= 1 && boom.is_a?(Errno::ENOTCONN) or
-           retries <= 1 && boom.is_a?(Errno::ECONNREFUSED) or
-           retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
+        if retries <= 1 &&
+          (boom.is_a?(Errno::ENOTCONN) or
+           boom.is_a?(Errno::ECONNREFUSED) or
+           boom.is_a?(IOError) && boom.message =~ /closed stream/i)
           retries += 1
           begin
             @socket = connect

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -45,6 +45,7 @@ module Datadog
         # Try once to reconnect if the socket has been closed
         retries ||= 1
         if retries <= 1 && boom.is_a?(Errno::ENOTCONN) or
+           retries <= 1 && boom.is_a?(Errno::ECONNREFUSED) or
            retries <= 1 && boom.is_a?(IOError) && boom.message =~ /closed stream/i
           retries += 1
           begin

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1016,7 +1016,7 @@ describe Datadog::Statsd do
       assert_allocations(6) { @statsd.increment('foobar') }
     end
 
-    it "produces low amounts of garbage for timeing" do
+    it "produces low amounts of garbage for timing" do
       assert_allocations(6) { @statsd.time('foobar') { 1111 } }
     end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -622,6 +622,37 @@ describe Datadog::Statsd do
     end
   end
 
+  describe "handling connection refused" do
+    before do
+      @statsd.connection.instance_variable_set(:@logger, Logger.new(@log = StringIO.new))
+    end
+
+    it "tries to reconnect once" do
+      @statsd.connection.expects(:socket).times(2).returns(socket)
+      socket.expects(:send).returns("YEP") # 2nd call
+      socket.expects(:send).raises(Errno::ECONNREFUSED.new("closed stream")) # first call
+
+      @statsd.increment('foobar')
+    end
+
+    it "ignores and logs if it fails to reconnect" do
+      @statsd.connection.expects(:socket).times(2).returns(socket)
+      socket.expects(:send).raises(RuntimeError) # 2nd call
+      socket.expects(:send).raises(Errno::ECONNREFUSED.new) # first call
+
+      assert_nil @statsd.increment('foobar')
+      @log.string.must_include 'Statsd: RuntimeError'
+    end
+
+    it "ignores and logs errors while trying to reconnect" do
+      socket.expects(:send).raises(Errno::ECONNREFUSED.new)
+      @statsd.connection.expects(:connect).raises(SocketError)
+
+      assert_nil @statsd.increment('foobar')
+      @log.string.must_include 'Statsd: SocketError'
+    end
+  end
+
   describe "UDS error handling" do
     before do
       @statsd = Datadog::Statsd.new('localhost', 1234, {:socket_path => '/tmp/socket'})


### PR DESCRIPTION
This PR adds error handling for `ECONNREFUSED`, and also fixes a small typo. This allows requests that fail due to a previous request encountering ECONNREFUSED to retry if the service on 8125 is available. Small edge case.