### PR TITLE
[events/service checks] Allow Integer date_happened / timestamp option

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -502,7 +502,18 @@ module Datadog
       # All pipes ('|') in the metadata are removed. Title and Text can keep theirs
       OPTS_KEYS.each do |key, shorthand_key|
         if key != :tags && opts[key]
-          value = remove_pipes(opts[key])
+          # :date_happened is the only key where the value is an Integer
+          if key == :date_happened
+            if opts[key].is_a? Integer
+              value = opts[key]
+            else
+              @logger.warn { "Statsd: Skipping event option #{key}, expected Integer type but got #{opts[key].class}" } if @logger
+              next # Skip this invalid key
+            end
+          # All other keys have String values
+          else
+              value = remove_pipes(opts[key])
+          end
           event_string_data << "|#{shorthand_key}:#{value}"
         end
       end

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -426,7 +426,7 @@ module Datadog
     # @param [String] title Event title
     # @param [String] text Event text. Supports newlines (+\n+)
     # @param [Hash] opts the additional data about the event
-    # @option opts [Integer, nil] :date_happened (nil) Assign a timestamp to the event. Default is now when none
+    # @option opts [Integer, String, nil] :date_happened (nil) Assign a timestamp to the event. Default is now when none
     # @option opts [String, nil] :hostname (nil) Assign a hostname to the event.
     # @option opts [String, nil] :aggregation_key (nil) Assign an aggregation key to the event, to group it with some others
     # @option opts [String, nil] :priority ('normal') Can be "normal" or "low"
@@ -503,14 +503,10 @@ module Datadog
       OPTS_KEYS.each do |key, shorthand_key|
         if key != :tags && opts[key]
           # :date_happened is the only key where the value is an Integer
-          if key == :date_happened
-            if opts[key].is_a? Integer
+          # To not break backwards compatibility, we still accept a String
+          if key == :date_happened && opts[key].is_a?(Integer)
               value = opts[key]
-            else
-              @logger.warn { "Statsd: Skipping event option #{key}, expected Integer type but got #{opts[key].class}" } if @logger
-              next # Skip this invalid key
-            end
-          # All other keys have String values
+          # All other keys only have String values
           else
               value = remove_pipes(opts[key])
           end

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -407,8 +407,8 @@ module Datadog
     # @param [String] name Service check name
     # @param [String] status Service check status.
     # @param [Hash] opts the additional data about the service check
-      # @option opts [Integer, nil] :timestamp (nil) Assign a timestamp to the event. Default is now when none
-      # @option opts [String, nil] :hostname (nil) Assign a hostname to the event.
+      # @option opts [Integer, String, nil] :timestamp (nil) Assign a timestamp to the service check. Default is now when none
+      # @option opts [String, nil] :hostname (nil) Assign a hostname to the service check.
       # @option opts [Array<String>, nil] :tags (nil) An array of tags
       # @option opts [String, nil] :message (nil) A message to associate with this service check status
     # @example Report a critical service check status
@@ -486,7 +486,11 @@ module Datadog
           escaped_message = escape_service_check_message(message)
           sc_string << "|m:#{escaped_message}"
         else
-          value = remove_pipes(opts[key])
+          if key == :timestamp && opts[key].is_a?(Integer)
+            value = opts[key]
+          else
+            value = remove_pipes(opts[key])
+          end
           sc_string << "|#{shorthand_key}#{value}"
         end
       end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -501,21 +501,6 @@ describe Datadog::Statsd do
     end
   end
 
-  describe "events with logging" do
-    require 'stringio'
-    let(:logger) { Logger.new(log) }
-    let(:log) { StringIO.new }
-    before { @statsd.instance_variable_set(:@logger, logger) }
-
-    it "writes wrong event option types in warning" do
-      logger.level = Logger::WARN
-
-      @statsd.event("title", "text", :date_happened => "blah")
-
-      log.string.must_match "Statsd: Skipping event option date_happened, expected Integer type but got String"
-    end
-  end
-
   describe "stat names" do
     it "should accept anything as stat" do
       @statsd.increment(Object)
@@ -917,13 +902,13 @@ describe Datadog::Statsd do
         @statsd.event(title, text, :priority => 'bizarre')
         socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|p:bizarre"]
       end
-      it "With date_happened" do
+      it "With Integer date_happened" do
         @statsd.event(title, text, :date_happened => timestamp)
         socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|d:#{timestamp}"]
       end
-      it "With wrong date_happened" do
-        @statsd.event(title, text, :date_happened => "blah")
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}"]
+      it "With String date_happened" do
+        @statsd.event(title, text, :date_happened => "#{timestamp}")
+        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|d:#{timestamp}"]
       end
       it "With hostname" do
         @statsd.event(title, text, :hostname => 'hostname_test')

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -958,6 +958,7 @@ describe Datadog::Statsd do
       name = Faker::Lorem.sentence(_word_count = rand(3))
       status = rand(4)
       hostname = "hostname_test"
+      timestamp = Time.parse('01-01-2000').to_i
       tags = Faker::Lorem.words(rand(1..10))
       tags_joined = tags.join(",")
 
@@ -974,6 +975,16 @@ describe Datadog::Statsd do
       it "sends with with message" do
         @statsd.service_check(name, status, :message => 'testing | m: \n')
         socket.recv.must_equal ["_sc|#{name}|#{status}|m:testing  m\\: \\n"]
+      end
+
+      it "With Integer timestamp" do
+        @statsd.service_check(name, status, :timestamp => timestamp)
+        socket.recv.must_equal ["_sc|#{name}|#{status}|d:#{timestamp}"]
+      end
+
+      it "With String timestamp" do
+        @statsd.service_check(name, status, :timestamp => "#{timestamp}")
+        socket.recv.must_equal ["_sc|#{name}|#{status}|d:#{timestamp}"]
       end
 
       it "sends with with tags" do


### PR DESCRIPTION
### What does this PR do?

When formatting events, we process all opts as if they're `Strings`,
but `date_happened` is actually an `Integer` timestamp.
Added logic and unit tests to handle this `Integer` option.

This fixes issue #100.

### Additional notes

I'm not sure if it's better to log a warning and ignore the option, raise an exception or do nothing and add the option in the event string whatever the value of `date_happened` is.

Should we also type check the `String` options? That could break some non-conventional use cases (for example, right now passing an array in the `hostname` option won't crash the client but shouldn't be accepted).

Thoughts @albertvaka?