### PR TITLE
[Gemfile] Remove Gemfile parts for ruby 1.9 CI tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,14 +25,5 @@ end
 group :test do
   gem 'tins', '~> 1.6.0'
   gem 'mocha'
-  if RUBY_VERSION.start_with?("1.9")
-    gem 'json', '< 2'
-    gem 'public_suffix', '< 1.5'
-    gem 'rdoc', '< 5'
-    gem 'term-ansicolor', '< 1.4'
-    gem 'webmock', '< 2.3'
-    gem 'nokogiri', '< 1.7'
-  else
-    gem 'json'
-  end
+  gem 'json'
 end


### PR DESCRIPTION
We're not testing ruby 1.9 in our CI tests, so we have no reason
to keep this part of the Gemfile.