### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/dogstatsd-ruby.gemspec
+++ b/dogstatsd-ruby.gemspec
@@ -11,12 +11,19 @@ Gem::Specification.new do |s|
   s.description = "A Ruby DogStastd client"
   s.email = "code@datadoghq.com"
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/DataDog/dogstatsd-ruby/issues",
+    "changelog_uri"     => "https://github.com/DataDog/dogstatsd-ruby/blob/v#{s.version}/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/dogstatsd-ruby/#{s.version}",
+    "source_code_uri"   => "https://github.com/DataDog/dogstatsd-ruby/tree/v#{s.version}"
+  }
+
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md"
   ]
   s.files = Dir["LICENSE.txt", "README.md", "lib/**/*.rb",]
-  s.homepage = "http://github.com/datadog/dogstatsd-ruby"
+  s.homepage = "https://github.com/DataDog/dogstatsd-ruby"
   s.licenses = ["MIT"]
   s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/dogstatsd-ruby and be available via the rubygems API after the next release.