### PR TITLE
Add a "bypass_sampling" option to metric methods

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -271,6 +271,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @option opts [Numeric] :by increment value, default 1
     # @see #count
@@ -285,6 +286,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @option opts [Numeric] :by decrement value, default 1
     # @see #count
@@ -300,6 +302,7 @@ module Datadog
     # @param [Integer] count count
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     def count(stat, count, opts=EMPTY_OPTIONS)
       opts = {:sample_rate => opts} if opts.is_a? Numeric
@@ -316,6 +319,7 @@ module Datadog
     # @param [Numeric] value gauge value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.gauge('user.count', User.count)
@@ -330,6 +334,7 @@ module Datadog
     # @param [Numeric] value histogram value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.histogram('user.count', User.count)
@@ -346,6 +351,7 @@ module Datadog
     # @param [Numeric] value distribution value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.distribution('user.count', User.count)
@@ -362,6 +368,7 @@ module Datadog
     # @param [Integer] ms timing in milliseconds
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     def timing(stat, ms, opts=EMPTY_OPTIONS)
       opts = {:sample_rate => opts} if opts.is_a? Numeric
@@ -376,6 +383,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @yield The operation to be timed
     # @see #timing
@@ -396,6 +404,7 @@ module Datadog
     # @param [Numeric] value set value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :bypass_sampling if true, do not actually sample the data, but still report the sample rate passed in. Use this if you're doing your own sampling
     # @option opts [Array<String>] :tags An array of tags
     # @example Record a unique visitory by id:
     #   $statsd.set('visitors.uniques', User.id)
@@ -564,7 +573,7 @@ module Datadog
 
     def send_stats(stat, delta, type, opts=EMPTY_OPTIONS)
       sample_rate = opts[:sample_rate] || @sample_rate || 1
-      if sample_rate == 1 or rand <= sample_rate
+      if sample_rate == 1 or opts[:bypass_sampling] or rand <= sample_rate
         full_stat = ''.dup
         full_stat << @prefix if @prefix
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -165,6 +165,14 @@ describe Datadog::Statsd do
       end
     end
 
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.increment('foobar', :sample_rate=>0.5, :bypass_sampling=>true)
+        socket.recv.must_equal ['foobar:1|c|@0.5']
+      end
+    end
+
     describe "with a increment by" do
       it "should increment by the number given" do
         @statsd.increment('foobar', :by=>5)
@@ -191,6 +199,14 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.decrement('foobar', 0.5)
+        socket.recv.must_equal ['foobar:-1|c|@0.5']
+      end
+    end
+
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.decrement('foobar', :sample_rate=>0.5, :bypass_sampling=>true)
         socket.recv.must_equal ['foobar:-1|c|@0.5']
       end
     end
@@ -233,6 +249,14 @@ describe Datadog::Statsd do
         socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
       end
     end
+
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.gauge('begrutten-suffusion', 536, :sample_rate=>0.1, :bypass_sampling=>true)
+        socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
+      end
+    end
   end
 
   describe "#histogram" do
@@ -248,6 +272,14 @@ describe Datadog::Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.gauge('begrutten-suffusion', 536, :sample_rate=>0.1)
         socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
+      end
+    end
+
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.histogram('ohmy', 536, :sample_rate=>0.1, :bypass_sampling=>true)
+        socket.recv.must_equal ['ohmy:536|h|@0.1']
       end
     end
   end
@@ -273,6 +305,14 @@ describe Datadog::Statsd do
         socket.recv.must_equal ['my.set:536|s|@0.5']
       end
     end
+
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.set('my.set', 536, :sample_rate=>0.5, :bypass_sampling=>true)
+        socket.recv.must_equal ['my.set:536|s|@0.5']
+      end
+    end
   end
 
   describe "#timing" do
@@ -293,6 +333,14 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.timing('foobar', 500, 0.5)
+        socket.recv.must_equal ['foobar:500|ms|@0.5']
+      end
+    end
+
+    describe "with sampling bypassed" do
+      before { class << @statsd; def rand; 1; end; end } # ensure that we wouldn't deliver if we checked
+      it "should include the sample rate but not sample itself" do
+        @statsd.timing('foobar', 500, :sample_rate=>0.5, :bypass_sampling=>true)
         socket.recv.must_equal ['foobar:500|ms|@0.5']
       end
     end


### PR DESCRIPTION
It is sometimes desirable to make a decision about sampling before
emitting the sampled metric, for instance if computing the set of tags
to associate with the metric is expensive. Even in these circumstances,
though, the metric sent to statsd should still be tagged with a sample
rate so that counts can be computed correctly.

This adds a "bypass_sampling" option. When true, metrics are always sent
to statsd, but are reported as having been sampled at the sample_rate
that is passed in. It's the caller's responsibility to ensure that
sampling actually occurs.