### PR TITLE
Adding telemetry to the dogstatsd client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rake', '10.1.0'
 gem 'rack', '~> 1.6'
 gem 'minitest'
+gem 'minitest-matchers'
 gem "yard", "~> 0.9.20"
 gem 'single_cov'
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -5,6 +5,7 @@ if RUBY_VERSION > "2.0"
   SingleCov.setup :minitest
 end
 
+require "minitest/matchers"
 require 'minitest/autorun'
 require 'mocha/minitest'
 require 'faker'
@@ -14,12 +15,54 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'datadog/statsd'
 require 'logger'
 
+class TelemetryMatcher
+
+  attr_accessor :text
+
+  def initialize(text, metrics, events, service_checks, bytes_sent, bytes_dropped, packets_sent, packets_dropped, transport)
+    telemetry = ["datadog.dogstatsd.client.metrics:#{metrics}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.events:#{events}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.service_checks:#{service_checks}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.bytes_sent:#{bytes_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.bytes_dropped:#{bytes_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.packets_sent:#{packets_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+                 "datadog.dogstatsd.client.packets_dropped:#{packets_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+    ].join("\n")
+    @text = "#{text}\n#{telemetry}"
+    @last_compare = ''
+  end
+
+  def length
+    @text.length
+  end
+
+  def matches?(subject)
+    @last_compare = subject
+    subject == @text
+  end
+
+  def failure_message_for_should
+    %(expected:
+#{@text}
+got:
+#{@last_compare}
+)
+  end
+end
+
+def equal_with_telemetry(text, metrics: 1, events: 0, service_checks: 0, bytes_sent: 0, bytes_dropped:0, packets_sent: 0, packets_dropped: 0, transport: "udp")
+  TelemetryMatcher.new(text, metrics, events, service_checks, bytes_sent, bytes_dropped, packets_sent, packets_dropped, transport)
+end
+MiniTest::Unit::TestCase.register_matcher :equal_with_telemetry, :equal_with_telemetry
+
 class FakeUDPSocket
   def initialize
     @buffer = []
+    @error_on_send = nil
   end
 
   def send(message, *)
+    raise @error_on_send if @error_on_send
     @buffer.push [message]
   end
 
@@ -33,5 +76,9 @@ class FakeUDPSocket
 
   def inspect
     "<FakeUDPSocket: #{@buffer.inspect}>"
+  end
+
+  def error_on_send(err)
+    @error_on_send = err
   end
 end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -11,6 +11,8 @@ describe Datadog::Statsd do
   class Datadog::Statsd
     # we need to stub this
     attr_accessor :socket
+    # we need to be able to access this
+    attr_accessor :telemetry
   end
 
   let(:namespace) { nil }
@@ -146,14 +148,14 @@ describe Datadog::Statsd do
   describe "#increment" do
     it "formats the message according to the statsd spec" do
       @statsd.increment('foobar')
-      socket.recv.must_equal ['foobar:1|c']
+      socket.recv[0].must equal_with_telemetry 'foobar:1|c'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.increment('foobar', :sample_rate=>0.5)
-        socket.recv.must_equal ['foobar:1|c|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:1|c|@0.5'
       end
     end
 
@@ -161,14 +163,14 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.increment('foobar', 0.5)
-        socket.recv.must_equal ['foobar:1|c|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:1|c|@0.5'
       end
     end
 
     describe "with a increment by" do
       it "should increment by the number given" do
         @statsd.increment('foobar', :by=>5)
-        socket.recv.must_equal ['foobar:5|c']
+        socket.recv[0].must equal_with_telemetry 'foobar:5|c'
       end
     end
   end
@@ -176,14 +178,14 @@ describe Datadog::Statsd do
   describe "#decrement" do
     it "should format the message according to the statsd spec" do
       @statsd.decrement('foobar')
-      socket.recv.must_equal ['foobar:-1|c']
+      socket.recv[0].must equal_with_telemetry 'foobar:-1|c'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.decrement('foobar', :sample_rate => 0.5)
-        socket.recv.must_equal ['foobar:-1|c|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:-1|c|@0.5'
       end
     end
 
@@ -191,14 +193,14 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.decrement('foobar', 0.5)
-        socket.recv.must_equal ['foobar:-1|c|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:-1|c|@0.5'
       end
     end
 
     describe "with a decrement by" do
       it "should decrement by the number given" do
         @statsd.decrement('foobar', :by=>5)
-        socket.recv.must_equal ['foobar:-5|c']
+        socket.recv[0].must equal_with_telemetry 'foobar:-5|c'
       end
     end
   end
@@ -213,16 +215,18 @@ describe Datadog::Statsd do
   describe "#gauge" do
     it "should send a message with a 'g' type, per the nearby fork" do
       @statsd.gauge('begrutten-suffusion', 536)
-      socket.recv.must_equal ['begrutten-suffusion:536|g']
+      socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:536|g'
+
+      @statsd.telemetry.reset
       @statsd.gauge('begrutten-suffusion', -107.3)
-      socket.recv.must_equal ['begrutten-suffusion:-107.3|g']
+      socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:-107.3|g'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.gauge('begrutten-suffusion', 536, :sample_rate=>0.1)
-        socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
+        socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
     end
 
@@ -230,7 +234,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.gauge('begrutten-suffusion', 536, 0.1)
-        socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
+        socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
     end
   end
@@ -238,16 +242,18 @@ describe Datadog::Statsd do
   describe "#histogram" do
     it "should send a message with a 'h' type, per the nearby fork" do
       @statsd.histogram('ohmy', 536)
-      socket.recv.must_equal ['ohmy:536|h']
+      socket.recv[0].must equal_with_telemetry 'ohmy:536|h'
+
+      @statsd.telemetry.reset
       @statsd.histogram('ohmy', -107.3)
-      socket.recv.must_equal ['ohmy:-107.3|h']
+      socket.recv[0].must equal_with_telemetry 'ohmy:-107.3|h'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.gauge('begrutten-suffusion', 536, :sample_rate=>0.1)
-        socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
+        socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
     end
   end
@@ -255,14 +261,14 @@ describe Datadog::Statsd do
   describe "#set" do
     it "should send a message with a 's' type, per the nearby fork" do
       @statsd.set('my.set', 536)
-      socket.recv.must_equal ['my.set:536|s']
+      socket.recv[0].must equal_with_telemetry 'my.set:536|s'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should send a message with a 's' type, per the nearby fork" do
         @statsd.set('my.set', 536, :sample_rate=>0.5)
-        socket.recv.must_equal ['my.set:536|s|@0.5']
+        socket.recv[0].must equal_with_telemetry 'my.set:536|s|@0.5'
       end
     end
 
@@ -270,7 +276,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should send a message with a 's' type, per the nearby fork" do
         @statsd.set('my.set', 536, 0.5)
-        socket.recv.must_equal ['my.set:536|s|@0.5']
+        socket.recv[0].must equal_with_telemetry 'my.set:536|s|@0.5'
       end
     end
   end
@@ -278,14 +284,14 @@ describe Datadog::Statsd do
   describe "#timing" do
     it "should format the message according to the statsd spec" do
       @statsd.timing('foobar', 500)
-      socket.recv.must_equal ['foobar:500|ms']
+      socket.recv[0].must equal_with_telemetry 'foobar:500|ms'
     end
 
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.timing('foobar', 500, :sample_rate=>0.5)
-        socket.recv.must_equal ['foobar:500|ms|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
       end
     end
 
@@ -293,7 +299,7 @@ describe Datadog::Statsd do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
       it "should format the message according to the statsd spec" do
         @statsd.timing('foobar', 500, 0.5)
-        socket.recv.must_equal ['foobar:500|ms|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
       end
     end
   end
@@ -308,7 +314,7 @@ describe Datadog::Statsd do
         @statsd.time('foobar') do
           stub_time 1
         end
-        socket.recv.must_equal ['foobar:1000|ms']
+        socket.recv[0].must equal_with_telemetry 'foobar:1000|ms'
       end
 
       it "should still time if block is failing" do
@@ -318,7 +324,7 @@ describe Datadog::Statsd do
             raise StandardError, 'This is failing'
           end
         end
-        socket.recv.must_equal ['foobar:1000|ms']
+        socket.recv[0].must equal_with_telemetry 'foobar:1000|ms'
       end
 
       def helper_time_return
@@ -330,7 +336,7 @@ describe Datadog::Statsd do
 
       it "should still time if block `return`s" do
         helper_time_return
-        socket.recv.must_equal ['foobar:1000|ms']
+        socket.recv[0].must equal_with_telemetry 'foobar:1000|ms'
       end
     end
 
@@ -359,7 +365,7 @@ describe Datadog::Statsd do
         @statsd.time('foobar', :sample_rate=>0.5) do
           stub_time 1
         end
-        socket.recv.must_equal ['foobar:1000|ms|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:1000|ms|@0.5'
       end
     end
 
@@ -370,7 +376,7 @@ describe Datadog::Statsd do
         @statsd.time('foobar', 0.5) do
           stub_time 1
         end
-        socket.recv.must_equal ['foobar:1000|ms|@0.5']
+        socket.recv[0].must equal_with_telemetry 'foobar:1000|ms|@0.5'
       end
     end
   end
@@ -381,7 +387,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; raise end; end }
         it "should send" do
           @statsd.timing('foobar', 500, :sample_rate=>1)
-          socket.recv.must_equal ['foobar:500|ms']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms'
         end
       end
 
@@ -389,7 +395,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; 0; end; end } # ensure delivery
         it "should send" do
           @statsd.timing('foobar', 500, :sample_rate=>0.5)
-          socket.recv.must_equal ['foobar:500|ms|@0.5']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
         end
       end
 
@@ -404,7 +410,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; 0.5; end; end } # ensure delivery
         it "should send" do
           @statsd.timing('foobar', 500, :sample_rate=>0.5)
-          socket.recv.must_equal ['foobar:500|ms|@0.5']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
         end
       end
     end
@@ -415,7 +421,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; raise end; end }
         it "should send" do
           @statsd.timing('foobar', 500)
-          socket.recv.must_equal ['foobar:500|ms']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms'
         end
       end
 
@@ -424,7 +430,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; 0; end; end } # ensure delivery
         it "should send" do
           @statsd.timing('foobar', 500)
-          socket.recv.must_equal ['foobar:500|ms|@0.5']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
         end
       end
 
@@ -441,7 +447,7 @@ describe Datadog::Statsd do
         before { class << @statsd; def rand; 0.5; end; end } # ensure delivery
         it "should send" do
           @statsd.timing('foobar', 500)
-          socket.recv.must_equal ['foobar:500|ms|@0.5']
+          socket.recv[0].must equal_with_telemetry 'foobar:500|ms|@0.5'
         end
       end
     end
@@ -450,7 +456,7 @@ describe Datadog::Statsd do
   describe "#distribution" do
     it "send a message with d type" do
       @statsd.distribution('begrutten-suffusion', 536)
-      socket.recv.must_equal ['begrutten-suffusion:536|d']
+      socket.recv[0].must equal_with_telemetry 'begrutten-suffusion:536|d'
     end
   end
 
@@ -459,22 +465,22 @@ describe Datadog::Statsd do
 
     it "should add namespace to increment" do
       @statsd.increment('foobar')
-      socket.recv.must_equal ['service.foobar:1|c']
+      socket.recv[0].must equal_with_telemetry 'service.foobar:1|c'
     end
 
     it "should add namespace to decrement" do
       @statsd.decrement('foobar')
-      socket.recv.must_equal ['service.foobar:-1|c']
+      socket.recv[0].must equal_with_telemetry 'service.foobar:-1|c'
     end
 
     it "should add namespace to timing" do
       @statsd.timing('foobar', 500)
-      socket.recv.must_equal ['service.foobar:500|ms']
+      socket.recv[0].must equal_with_telemetry 'service.foobar:500|ms'
     end
 
     it "should add namespace to gauge" do
       @statsd.gauge('foobar', 500)
-      socket.recv.must_equal ['service.foobar:500|g']
+      socket.recv[0].must equal_with_telemetry 'service.foobar:500|g'
     end
   end
 
@@ -510,12 +516,12 @@ describe Datadog::Statsd do
       class Datadog::Statsd::SomeClass; end
       @statsd.increment(Datadog::Statsd::SomeClass, :sample_rate=>1)
 
-      socket.recv.must_equal ['Datadog.Statsd.SomeClass:1|c']
+      socket.recv[0].must equal_with_telemetry 'Datadog.Statsd.SomeClass:1|c'
     end
 
     it "should replace statsd reserved chars in the stat name" do
       @statsd.increment('ray@hostname.blah|blah.blah:blah')
-      socket.recv.must_equal ['ray_hostname.blah_blah.blah_blah:1|c']
+      socket.recv[0].must equal_with_telemetry 'ray_hostname.blah_blah.blah_blah:1|c'
     end
 
     it "should handle frozen strings" do
@@ -526,7 +532,7 @@ describe Datadog::Statsd do
   describe "tag names" do
     it "replaces reserved chars for tags" do
       @statsd.increment('stat', tags: ["name:foo,bar|foo"])
-      socket.recv.must_equal ['stat:1|c|#name:foobarfoo']
+      socket.recv[0].must equal_with_telemetry 'stat:1|c|#name:foobarfoo'
     end
 
     it "handles the cases when some tags are frozen strings" do
@@ -535,7 +541,7 @@ describe Datadog::Statsd do
 
     it "converts all values to strings" do
       @statsd.increment('stat', tags: [:sample_tag])
-      socket.recv.must_equal ['stat:1|c|#sample_tag']
+      socket.recv[0].must equal_with_telemetry 'stat:1|c|#sample_tag'
     end
   end
 
@@ -590,7 +596,7 @@ describe Datadog::Statsd do
       @log.string.must_include 'Statsd: SocketError'
     end
   end
-  
+
   describe "handling not connected socket" do
     before do
       @statsd.connection.instance_variable_set(:@logger, Logger.new(@log = StringIO.new))
@@ -655,7 +661,7 @@ describe Datadog::Statsd do
 
   describe "UDS error handling" do
     before do
-      @statsd = Datadog::Statsd.new('localhost', 1234, {:socket_path => '/tmp/socket'})
+      @statsd = Datadog::Statsd.new('localhost', 1234, socket_path: '/tmp/socket', disable_telemetry: true)
     end
 
     describe "when socket throws connection reset error" do
@@ -732,7 +738,7 @@ describe Datadog::Statsd do
         @fake_socket2.verify
       end
     end
-    
+
     describe "when socket is full" do
       before do
         @fake_socket = Minitest::Mock.new
@@ -762,23 +768,25 @@ describe Datadog::Statsd do
     describe "tags as an array of strings" do
       it "gauges support tags" do
         @statsd.gauge("gauge", 1, :tags=>%w(country:usa state:ny))
-        socket.recv.must_equal ['gauge:1|g|#country:usa,state:ny']
+        socket.recv[0].must equal_with_telemetry 'gauge:1|g|#country:usa,state:ny'
       end
 
       it "counters support tags" do
         @statsd.increment("c", :tags=>%w(country:usa other))
-        socket.recv.must_equal ['c:1|c|#country:usa,other']
+        socket.recv[0].must equal_with_telemetry 'c:1|c|#country:usa,other'
 
+        @statsd.telemetry.reset
         @statsd.decrement("c", :tags=>%w(country:china))
-        socket.recv.must_equal ['c:-1|c|#country:china']
+        socket.recv[0].must equal_with_telemetry 'c:-1|c|#country:china'
 
+        @statsd.telemetry.reset
         @statsd.count("c", 100, :tags=>%w(country:finland))
-        socket.recv.must_equal ['c:100|c|#country:finland']
+        socket.recv[0].must equal_with_telemetry 'c:100|c|#country:finland'
       end
 
       it "timing support tags" do
         @statsd.timing("t", 200, :tags=>%w(country:canada other))
-        socket.recv.must_equal ['t:200|ms|#country:canada,other']
+        socket.recv[0].must equal_with_telemetry 't:200|ms|#country:canada,other'
 
         @statsd.time('foobar', :tags => ["123"]) { sleep(0.001); 'test' }
       end
@@ -786,36 +794,38 @@ describe Datadog::Statsd do
       it "global tags setter" do
         @statsd.instance_variable_set(:@tags, %w(country:usa other))
         @statsd.increment("c")
-        socket.recv.must_equal ['c:1|c|#country:usa,other']
+        socket.recv[0].must equal_with_telemetry 'c:1|c|#country:usa,other'
       end
 
       it "global tags setter and regular tags" do
         @statsd.instance_variable_set(:@tags, %w(country:usa other))
         @statsd.increment("c", :tags=>%w(somethingelse))
-        socket.recv.must_equal ['c:1|c|#country:usa,other,somethingelse']
+        socket.recv[0].must equal_with_telemetry 'c:1|c|#country:usa,other,somethingelse'
       end
     end
 
     describe "tags as hashes" do
       it "gauges support tags" do
         @statsd.gauge("gauge", 1, :tags =>{ country: 'usa', state: 'ny' })
-        socket.recv.must_equal ['gauge:1|g|#country:usa,state:ny']
+        socket.recv[0].must equal_with_telemetry 'gauge:1|g|#country:usa,state:ny'
       end
 
       it "counters support tags" do
         @statsd.increment("c", :tags => { country: 'usa', other: nil })
-        socket.recv.must_equal ['c:1|c|#country:usa,other']
+        socket.recv[0].must equal_with_telemetry 'c:1|c|#country:usa,other'
 
+        @statsd.telemetry.reset
         @statsd.decrement("c", :tags => { country: 'china' })
-        socket.recv.must_equal ['c:-1|c|#country:china']
+        socket.recv[0].must equal_with_telemetry 'c:-1|c|#country:china'
 
+        @statsd.telemetry.reset
         @statsd.count("c", 100, :tags => { country: 'finland' })
-        socket.recv.must_equal ['c:100|c|#country:finland']
+        socket.recv[0].must equal_with_telemetry 'c:100|c|#country:finland'
       end
 
       it "timing support tags" do
         @statsd.timing("t", 200, :tags => { country: 'canada', other: nil })
-        socket.recv.must_equal ['t:200|ms|#country:canada,other']
+        socket.recv[0].must equal_with_telemetry 't:200|ms|#country:canada,other'
 
         @statsd.time('foobar', :tags => ["123"]) { sleep(0.001); 'test' }
       end
@@ -823,7 +833,7 @@ describe Datadog::Statsd do
       it "global tags setter and regular tags" do
         @statsd.instance_variable_set(:@tags, %w(country:usa other))
         @statsd.increment("c", :tags=> { something: 'else'})
-        socket.recv.must_equal ['c:1|c|#country:usa,other,something:else']
+        socket.recv[0].must equal_with_telemetry 'c:1|c|#country:usa,other,something:else'
       end
 
     end
@@ -839,7 +849,7 @@ describe Datadog::Statsd do
       @statsd.batch do |s|
         s.increment("mycounter")
       end
-      socket.recv.must_equal ['mycounter:1|c']
+      socket.recv[0].must equal_with_telemetry 'mycounter:1|c'
     end
 
     it "should allow to send multiple sample in one packet" do
@@ -847,7 +857,7 @@ describe Datadog::Statsd do
         s.increment("mycounter")
         s.decrement("myothercounter")
       end
-      socket.recv.must_equal ["mycounter:1|c\nmyothercounter:-1|c"]
+      socket.recv[0].must equal_with_telemetry("mycounter:1|c\nmyothercounter:-1|c", metrics: 2)
     end
 
     it "should default back to single metric packet after the block" do
@@ -857,26 +867,44 @@ describe Datadog::Statsd do
       end
       @statsd.increment("mycounter")
       @statsd.increment("myothercounter")
-      socket.recv.must_equal ["mygauge:10|g\nmyothergauge:20|g"]
-      socket.recv.must_equal ['mycounter:1|c']
-      socket.recv.must_equal ['myothercounter:1|c']
+
+      equal_expected = equal_with_telemetry("mygauge:10|g\nmyothergauge:20|g", metrics: 2)
+      socket.recv[0].must equal_expected
+
+      equal_expected = equal_with_telemetry('mycounter:1|c', bytes_sent: equal_expected.length, packets_sent: 1)
+      socket.recv[0].must equal_expected
+
+      equal_expected = equal_with_telemetry('myothercounter:1|c', bytes_sent: equal_expected.length, packets_sent: 1)
+      socket.recv[0].must equal_expected
     end
 
     it "should flush when the buffer gets too big" do
       expected_message = 'mycounter:1|c'
-      number_of_messages_to_fill_the_buffer = (8192 - 1) / (expected_message.bytesize + 1)
+      previous_payload_length = 0
+
       @statsd.batch do |s|
         # increment a counter to fill the buffer and trigger buffer flush
+        buffer_size = Datadog::Statsd::DEFAULT_BUFFER_SIZE - @statsd.telemetry.estimate_max_size() - 1
+
+        number_of_messages_to_fill_the_buffer = buffer_size / (expected_message.bytesize + 1)
+        theoretical_reply = Array.new(number_of_messages_to_fill_the_buffer) { expected_message }
+
         (number_of_messages_to_fill_the_buffer + 1).times do
           s.increment("mycounter")
         end
 
-        theoretical_reply = Array.new(number_of_messages_to_fill_the_buffer) { 'mycounter:1|c' }
-        socket.recv.must_equal [theoretical_reply.join("\n")]
+        equal_expected = equal_with_telemetry(theoretical_reply.join("\n"), metrics: number_of_messages_to_fill_the_buffer+1)
+        socket.recv[0].must equal_expected
+        previous_payload_length = equal_expected.length
       end
 
-      # When the block finishes, the remaining buffer is flushed
-      socket.recv.must_equal ['mycounter:1|c']
+      # When the block finishes, the remaining buffer is flushed.
+      #
+      # We increment the telemetry metrics count when we receive it, not when
+      # flush. This means that the last metric (who filled the buffer and triggered a
+      # flush) increment the telemetry but was not sent. Then once the 'do' block
+      # finishes we flush the buffer with a telemtry of 0 metrics being received.
+      socket.recv[0].must equal_with_telemetry(expected_message, metrics: 0, bytes_sent: previous_payload_length, packets_sent: 1)
     end
 
     it "should batch nested batch blocks" do
@@ -888,10 +916,11 @@ describe Datadog::Statsd do
         @statsd.increment("level-1-again")
       end
       # all three should be sent in a single batch when the outer block finishes
-      socket.recv.must_equal ["level-1:1|c\nlevel-2:1|c\nlevel-1-again:1|c"]
+      equal_expected = equal_with_telemetry("level-1:1|c\nlevel-2:1|c\nlevel-1-again:1|c", metrics: 3)
+      socket.recv[0].must equal_expected
       # we should revert back to sending single metric packets
       @statsd.increment("outside")
-      socket.recv.must_equal ["outside:1|c"]
+      socket.recv[0].must equal_with_telemetry("outside:1|c", bytes_sent: equal_expected.length, packets_sent: 1)
     end
   end
 
@@ -905,13 +934,13 @@ describe Datadog::Statsd do
 
       it "Only title and text" do
         @statsd.event(title, text)
-        socket.recv.must_equal [@statsd.send(:format_event, title, text)]
+        socket.recv[0].must equal_with_telemetry(@statsd.send(:format_event, title, text), metrics: 0, events: 1)
       end
       it "With line break in Text and title" do
         title_break_line = "#{title} \n second line"
         text_break_line = "#{text} \n second line"
         @statsd.event(title_break_line, text_break_line)
-        socket.recv.must_equal [@statsd.send(:format_event, title_break_line, text_break_line)]
+        socket.recv[0].must equal_with_telemetry(@statsd.send(:format_event, title_break_line, text_break_line), metrics: 0, events: 1)
       end
       it "Event data string too long > 8KB" do
         long_text = "#{text} " * 200000
@@ -919,57 +948,57 @@ describe Datadog::Statsd do
       end
       it "With known alert_type" do
         @statsd.event(title, text, :alert_type => 'warning')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|t:warning"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|t:warning", metrics: 0, events: 1)
       end
       it "With unknown alert_type" do
         @statsd.event(title, text, :alert_type => 'bizarre')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|t:bizarre"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|t:bizarre", metrics: 0, events: 1)
       end
       it "With known priority" do
         @statsd.event(title, text, :priority => 'low')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|p:low"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|p:low", metrics: 0, events: 1)
       end
       it "With unknown priority" do
         @statsd.event(title, text, :priority => 'bizarre')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|p:bizarre"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|p:bizarre", metrics: 0, events: 1)
       end
       it "With Integer date_happened" do
         @statsd.event(title, text, :date_happened => timestamp)
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|d:#{timestamp}"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|d:#{timestamp}", metrics: 0, events: 1)
       end
       it "With String date_happened" do
         @statsd.event(title, text, :date_happened => "#{timestamp}")
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|d:#{timestamp}"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|d:#{timestamp}", metrics: 0, events: 1)
       end
       it "With hostname" do
         @statsd.event(title, text, :hostname => 'hostname_test')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|h:hostname_test"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|h:hostname_test", metrics: 0, events: 1)
       end
       it "With aggregation_key" do
         @statsd.event(title, text, :aggregation_key => 'aggkey 1')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|k:aggkey 1"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|k:aggkey 1", metrics: 0, events: 1)
       end
       it "With source_type_name" do
         @statsd.event(title, text, :source_type_name => 'source 1')
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|s:source 1"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|s:source 1", metrics: 0, events: 1)
       end
       it "With several tags" do
         @statsd.event(title, text, :tags => tags)
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text)}|##{tags_joined}"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text)}|##{tags_joined}", metrics: 0, events: 1)
       end
       it "Takes into account the common tags" do
         basic_result = @statsd.send(:format_event, title, text)
         common_tag = 'common'
         @statsd.instance_variable_set :@tags, [common_tag]
         @statsd.event(title, text)
-        socket.recv.must_equal ["#{basic_result}|##{common_tag}"]
+        socket.recv[0].must equal_with_telemetry("#{basic_result}|##{common_tag}", metrics: 0, events: 1)
       end
       it "combines common and specific tags" do
         basic_result = @statsd.send(:format_event, title, text)
         common_tag = 'common'
         @statsd.instance_variable_set :@tags, [common_tag]
         @statsd.event(title, text, :tags => tags)
-        socket.recv.must_equal ["#{basic_result}|##{common_tag},#{tags_joined}"]
+        socket.recv[0].must equal_with_telemetry("#{basic_result}|##{common_tag},#{tags_joined}", metrics: 0, events: 1)
       end
       it "With alert_type, priority, hostname, several tags" do
         @statsd.event(title, text, :alert_type => 'warning', :priority => 'low', :hostname => 'hostname_test', :tags => tags)
@@ -979,7 +1008,7 @@ describe Datadog::Statsd do
           :hostname => 'hostname_test',
           :tags => tags
         }
-        socket.recv.must_equal ["#{@statsd.send(:format_event, title, text, opts)}"]
+        socket.recv[0].must equal_with_telemetry("#{@statsd.send(:format_event, title, text, opts)}", metrics: 0, events: 1)
       end
     end
   end
@@ -995,32 +1024,32 @@ describe Datadog::Statsd do
 
       it "sends with only name and status" do
         @statsd.service_check(name, status)
-        socket.recv.must_equal [@statsd.send(:format_service_check, name, status)]
+        socket.recv[0].must equal_with_telemetry(@statsd.send(:format_service_check, name, status), metrics: 0, service_checks: 1)
       end
 
       it "sends with with hostname" do
         @statsd.service_check(name, status, :hostname => hostname)
-        socket.recv.must_equal ["_sc|#{name}|#{status}|h:#{hostname}"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|h:#{hostname}", metrics: 0, service_checks: 1)
       end
 
       it "sends with with message" do
         @statsd.service_check(name, status, :message => 'testing | m: \n')
-        socket.recv.must_equal ["_sc|#{name}|#{status}|m:testing  m\\: \\n"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|m:testing  m\\: \\n", metrics: 0, service_checks: 1)
       end
 
       it "With Integer timestamp" do
         @statsd.service_check(name, status, :timestamp => timestamp)
-        socket.recv.must_equal ["_sc|#{name}|#{status}|d:#{timestamp}"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|d:#{timestamp}", metrics: 0, service_checks: 1)
       end
 
       it "With String timestamp" do
         @statsd.service_check(name, status, :timestamp => "#{timestamp}")
-        socket.recv.must_equal ["_sc|#{name}|#{status}|d:#{timestamp}"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|d:#{timestamp}", metrics: 0, service_checks: 1)
       end
 
       it "sends with with tags" do
         @statsd.service_check(name, status, :tags => tags)
-        socket.recv.must_equal ["_sc|#{name}|#{status}|##{tags_joined}"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|##{tags_joined}", metrics: 0, service_checks: 1)
       end
 
       it "sends with with hostname, message, and tags" do
@@ -1028,8 +1057,93 @@ describe Datadog::Statsd do
           name, status,
           :message => 'testing | m: \n', :hostname => 'hostname_test', :tags => tags
         )
-        socket.recv.must_equal ["_sc|#{name}|#{status}|h:#{hostname}|##{tags_joined}|m:testing  m\\: \\n"]
+        socket.recv[0].must equal_with_telemetry("_sc|#{name}|#{status}|h:#{hostname}|##{tags_joined}|m:testing  m\\: \\n", metrics: 0, service_checks: 1)
       end
+    end
+  end
+
+  describe "telemetry" do
+    it "should not be sent when disabled" do
+      statsd = Datadog::Statsd.new('localhost', 1234, disable_telemetry: true)
+      statsd.connection.instance_variable_set(:@socket, socket)
+
+      statsd.count("test", 21)
+      socket.recv[0].must_equal "test:21|c"
+    end
+
+    it "should send by default" do
+      statsd = Datadog::Statsd.new('localhost', 1234)
+      statsd.connection.instance_variable_set(:@socket, socket)
+
+      statsd.count("test", 21)
+      socket.recv[0].must equal_with_telemetry "test:21|c"
+    end
+
+    it "should handle all data type" do
+      @statsd.increment("test", 1)
+      socket.recv[0].must equal_with_telemetry("test:1|c", metrics: 1, packets_sent: 0, bytes_sent: 0)
+
+      @statsd.decrement("test", 1)
+      socket.recv[0].must equal_with_telemetry("test:-1|c", metrics: 1, packets_sent: 1, bytes_sent: 680)
+
+      @statsd.count("test", 21)
+      socket.recv[0].must equal_with_telemetry("test:21|c", metrics: 1, packets_sent: 1, bytes_sent: 683)
+
+      @statsd.gauge("test", 21)
+      socket.recv[0].must equal_with_telemetry("test:21|g", metrics: 1, packets_sent: 1, bytes_sent: 683)
+
+      @statsd.histogram("test", 21)
+      socket.recv[0].must equal_with_telemetry("test:21|h", metrics: 1, packets_sent: 1, bytes_sent: 683)
+
+      @statsd.timing("test", 21)
+      socket.recv[0].must equal_with_telemetry("test:21|ms", metrics: 1, packets_sent: 1, bytes_sent: 683)
+
+      @statsd.set("test", 21)
+      socket.recv[0].must equal_with_telemetry("test:21|s", metrics: 1, packets_sent: 1, bytes_sent: 684)
+
+      @statsd.service_check("sc", 0)
+      socket.recv[0].must equal_with_telemetry("_sc|sc|0", metrics: 0, service_checks: 1, packets_sent: 1, bytes_sent: 683)
+
+      @statsd.event("ev", "text")
+      socket.recv[0].must equal_with_telemetry("_e{2,4}:ev|text", metrics: 0, events: 1, packets_sent: 1, bytes_sent: 682)
+    end
+
+    it "should handle all data type when batched" do
+      @statsd.batch do |s|
+        s.increment("test", 1)
+        s.decrement("test", 1)
+        s.count("test", 21)
+        s.gauge("test", 21)
+        s.histogram("test", 21)
+        s.timing("test", 21)
+        s.set("test", 21)
+        s.service_check("sc", 0)
+        s.event("ev", "text")
+      end
+
+      socket.recv[0].must equal_with_telemetry("test:1|c\ntest:-1|c\ntest:21|c\ntest:21|g\ntest:21|h\ntest:21|ms\ntest:21|s\n_sc|sc|0\n_e{2,4}:ev|text", metrics: 7, service_checks: 1, events: 1)
+      @statsd.telemetry.flush().must equal_with_telemetry("", metrics: 0, service_checks: 0, events: 0, packets_sent: 1, bytes_sent: 766)
+    end
+
+    it "should handle dropped data" do
+      s = FakeUDPSocket.new
+      s.error_on_send "some error"
+
+      statsd = Datadog::Statsd.new('localhost', 1234)
+      statsd.connection.instance_variable_set(:@socket, s)
+
+      statsd.gauge("test", 21)
+      statsd.telemetry.flush().must equal_with_telemetry("", metrics: 1, service_checks: 0, events: 0, packets_dropped: 1, bytes_dropped: 681)
+      statsd.gauge("test", 21)
+      statsd.telemetry.flush().must equal_with_telemetry("", metrics: 2, service_checks: 0, events: 0, packets_dropped: 2, bytes_dropped: 1364)
+
+      #disable network failure
+      s.error_on_send nil
+
+      statsd.gauge("test", 21)
+      s.recv[0].must equal_with_telemetry("test:21|g", metrics: 3, service_checks: 0, events: 0, packets_dropped: 2, bytes_dropped: 1364)
+
+      statsd.telemetry.flush().must equal_with_telemetry("", metrics: 0, service_checks: 0, events: 0, packets_sent: 1, bytes_sent: 684)
     end
   end
 
@@ -1044,11 +1158,18 @@ describe Datadog::Statsd do
     before { skip('AllocationStats is not available: skipping.') unless defined?(AllocationStats) }
 
     it "produces low amounts of garbage for simple methods" do
-      assert_allocations(6) { @statsd.increment('foobar') }
+      assert_allocations(15) { @statsd.increment('foobar') }
     end
 
     it "produces low amounts of garbage for timing" do
-      assert_allocations(6) { @statsd.time('foobar') { 1111 } }
+      assert_allocations(15) { @statsd.time('foobar') { 1111 } }
+    end
+
+    it "produces low amounts of garbage for simple methods without telemetry" do
+      statsd = Datadog::Statsd.new('localhost', 1234, namespace: namespace, sample_rate: sample_rate, disable_telemetry: true)
+      statsd.connection.instance_variable_set(:@socket, socket)
+      assert_allocations(7) { statsd.increment('foobar') }
+      assert_allocations(7) { statsd.time('foobar') { 1111 } }
     end
 
     def assert_allocations(count, &block)


### PR DESCRIPTION
Having client side telemetry is very helpful in troubleshooting packet drop between the client and the datadog-agent.