### PR TITLE
Small optimizations

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -327,7 +327,7 @@ module Datadog
 
     if PROCESS_TIME_SUPPORTED
       def now
-        Process.clock_gettime(Process::CLOCK_MONOTONIC) # uncovered
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     else
       def now

--- a/lib/datadog/statsd/telemetry.rb
+++ b/lib/datadog/statsd/telemetry.rb
@@ -46,7 +46,7 @@ module Datadog
         @bytes_dropped = 0
         @packets_sent = 0
         @packets_dropped = 0
-        @next_flush_time = Time.now.to_i + @flush_interval
+        @next_flush_time = now_in_s + @flush_interval
       end
 
       def sent(metrics: 0, events: 0, service_checks: 0, bytes: 0, packets: 0)
@@ -64,7 +64,7 @@ module Datadog
       end
 
       def flush?
-        @next_flush_time < Time.now.to_i
+        @next_flush_time < now_in_s
       end
 
       def flush
@@ -83,6 +83,16 @@ datadog.dogstatsd.client.packets_dropped:#{@packets_dropped}|#{COUNTER_TYPE}|##{
 
       private
       attr_reader :serialized_tags
+
+      if Kernel.const_defined?(Process) && Process.respond_to?(:clock_gettime)
+        def now_in_s
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+        end
+      else
+        def now_in_s
+          Time.now.to_i
+        end
+      end
     end
   end
 end

--- a/lib/datadog/statsd/telemetry.rb
+++ b/lib/datadog/statsd/telemetry.rb
@@ -84,7 +84,7 @@ datadog.dogstatsd.client.packets_dropped:#{@packets_dropped}|#{COUNTER_TYPE}|##{
       private
       attr_reader :serialized_tags
 
-      if Kernel.const_defined?(Process) && Process.respond_to?(:clock_gettime)
+      if Kernel.const_defined?('Process') && Process.respond_to?(:clock_gettime)
         def now_in_s
           Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
         end

--- a/spec/integrations/allocation_spec.rb
+++ b/spec/integrations/allocation_spec.rb
@@ -43,11 +43,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        22
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        19
-      else
         18
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+        17
+      else
+        16
       end
     end
 
@@ -70,11 +70,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          11
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           9
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           8
+        else
+          7
         end
       end
 
@@ -88,11 +88,11 @@ describe 'Allocations and garbage collection' do
     context 'with tags' do
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          30
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          27
-        else
           26
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+          25
+        else
+          24
         end
       end
 
@@ -112,11 +112,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        22
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        19
-      else
         18
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+        17
+      else
+        16
       end
     end
 
@@ -139,11 +139,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          11
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           9
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           8
+        else
+          7
         end
       end
 
@@ -157,11 +157,11 @@ describe 'Allocations and garbage collection' do
     context 'with tags' do
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          30
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          27
-        else
           26
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+          25
+        else
+          24
         end
       end
 
@@ -181,11 +181,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        23
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        20
-      else
         19
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+        18
+      else
+        17
       end
     end
 
@@ -208,11 +208,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          12
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           10
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           9
+        else
+          8
         end
       end
 
@@ -226,11 +226,11 @@ describe 'Allocations and garbage collection' do
     context 'with tags' do
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          32
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          29
-        else
           28
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+          27
+        else
+          26
         end
       end
 
@@ -250,11 +250,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        19
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        16
-      else
         15
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+        14
+      else
+        13
       end
     end
 
@@ -277,11 +277,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          8
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           6
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           5
+        else
+          4
         end
       end
 
@@ -295,11 +295,11 @@ describe 'Allocations and garbage collection' do
     context 'with tags' do
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          28
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          25
-        else
           24
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+          23
+        else
+          22
         end
       end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -500,13 +500,14 @@ describe Datadog::Statsd do
 
     before do
       Timecop.freeze(before_date)
-      allow(Process).to receive(:clock_gettime).and_return(0, 1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
+      allow(Process).to receive(:clock_gettime).and_return(0) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
     end
 
     it_behaves_like 'a metrics method', 'foobar:1000|ms' do
       let(:basic_action) do
         subject.time('foobar', tags: action_tags) do
           Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
       end
     end
@@ -515,6 +516,7 @@ describe Datadog::Statsd do
       it 'sends the timing' do
         subject.time('foobar') do
           Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms'
@@ -524,6 +526,7 @@ describe Datadog::Statsd do
         # rubocop:disable Lint/RescueWithoutErrorClass
         subject.time('foobar') do
           Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
           raise 'stop'
         end rescue nil
         # rubocop:enable Lint/RescueWithoutErrorClass
@@ -560,6 +563,7 @@ describe Datadog::Statsd do
       it 'sends the timing with the sample rate' do
         subject.time('foobar', sample_rate: 0.5) do
           Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
@@ -574,6 +578,7 @@ describe Datadog::Statsd do
       it 'sends the timing with the sample rate' do
         subject.time('foobar', 0.5) do
           Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
@@ -924,6 +929,7 @@ describe Datadog::Statsd do
     context 'when flusing only every 2 seconds' do
       before do
         Timecop.freeze(DateTime.new(2020, 2, 22, 12, 12, 12))
+        allow(Process).to receive(:clock_gettime).and_return(0) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         subject
       end
 
@@ -943,6 +949,7 @@ describe Datadog::Statsd do
 
       it 'does not send telemetry before the delay' do
         Timecop.freeze(DateTime.new(2020, 2, 22, 12, 12, 13))
+        allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
 
         subject.count('test', 21)
 
@@ -951,6 +958,7 @@ describe Datadog::Statsd do
 
       it 'sends telemetry after the delay' do
         Timecop.freeze(DateTime.new(2020, 2, 22, 12, 12, 15))
+        allow(Process).to receive(:clock_gettime).and_return(3) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
 
         subject.count('test', 21)
 


### PR DESCRIPTION
Hi,

I've added a couple small optimizations.  The first one removes a runtime check of a constant.  We can know whether or not `Process.clock_gettime` is supported at file require time, so we can eliminate a conditional in `time`.

The other optimization eliminates object allocations inside the `Telemetry` class.  We can (and should) use monotonic time there in order to eliminate allocations and also not be subject to clock changes.  Unfortunately that file seems to be tested with `Timecop`, and Timecop apparently doesn't support mocking `Process.clock_gettime`: https://github.com/travisjeffery/timecop/issues/220

The changes I made _should_ be equivalent to the `Time.now.to_i` call.  I will try to get the tests passing later, but maybe someone more familiar can do it too?

I used this as a benchmark:

```ruby
# frozen_string_literal: true

require 'datadog/statsd'
require 'logger'
require 'benchmark/ips'
require 'stackprof'

logger = Logger.new $stderr
logger.level = Logger::INFO

thing = Datadog::Statsd.new('localhost', 1234,
                    namespace: "sample_ns",
                    sample_rate: nil,
                    tags: %w{ abc def },
                    logger: nil,
                    telemetry_flush_interval: -1,
                   )

Benchmark.ips do |x|
  x.report("time") { thing.time("foobar") { } }
end
```

On master, I get:

```
$ ruby -I lib:spec time_speed.rb
Warming up --------------------------------------
                time     4.463k i/100ms
Calculating -------------------------------------
                time     47.775k (± 6.9%) i/s -    241.002k in   5.076456s
```

On this branch I get:

```
$ ruby -I lib:spec time_speed.rb
Warming up --------------------------------------
                time     4.700k i/100ms
Calculating -------------------------------------
                time     50.365k (± 7.7%) i/s -    253.800k in   5.078403s
```

I also measured allocations.  Here is the benchmark for allocations:

```ruby
# frozen_string_literal: true

require 'datadog/statsd'
require 'logger'
require 'benchmark/ips'
require 'stackprof'

logger = Logger.new $stderr
logger.level = Logger::INFO

thing = Datadog::Statsd.new('localhost', 1234,
                    namespace: "sample_ns",
                    sample_rate: nil,
                    tags: %w{ abc def },
                    logger: nil,
                    telemetry_flush_interval: -1,
                   )

def allocs
  x = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - x
end

p allocs { 50.times { thing.time("foobar") { } } }
```

On master:

```
$ ruby -I lib:spec time_speed.rb
1752
```

On this branch:

```
$ ruby -I lib:spec time_speed.rb
1160
```

I guess that's about 11 allocations saved per call to `time`.