### PR TITLE
Add support for more environment variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'minitest'
 gem 'minitest-matchers'
 gem 'yard', '~> 0.9.20'
 gem 'single_cov'
+gem 'climate_control'
 
 if RUBY_VERSION >= '2.0.0'
   gem 'rubocop', '~> 0.50.0' # bump this and TargetRubyVersion once we drop ruby 2.0

--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -10,7 +10,7 @@ module Datadog
       # Close the underlying socket
       def close
         begin
-          @socket && @socket.close
+          @socket && @socket.close if instance_variable_defined?(:@socket)
         rescue StandardError => boom
           logger.error { "Statsd: #{boom.class} #{boom}" } if logger
         end

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -37,11 +37,11 @@ module Datadog
             tags.dup
           when Array
             Hash[
-              tags.collect do |string|
-                string.split(':').tap do |tokens|
-                  tokens << nil if tokens.length == 1
-                end
-              end
+              tags.map do |string|
+                tokens = string.split(':')
+                tokens << nil if tokens.length == 1
+                tokens.length == 2 ? tokens : nil
+              end.compact
             ]
           else
             {}

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'set'
 
 module Datadog
   class Statsd
@@ -72,13 +71,19 @@ module Datadog
           tag.to_s.delete('|,')
         end
 
+        def dd_tags(env = ENV)
+          return {} unless dd_tags = env['DD_TAGS']
+
+          to_tags_hash(dd_tags.split(','))
+        end
+
         def default_tags(env = ENV)
-          tags = env.key?('DD_TAGS') ? to_tags_hash(env['DD_TAGS'].split(',')) : {}
-          tags['dd.internal.entity_id'] = env['DD_ENTITY_ID'] if env.key?('DD_ENTITY_ID')
-          tags['env'] = env['DD_ENV'] if env.key?('DD_ENV')
-          tags['service'] = env['DD_SERVICE'] if env.key?('DD_SERVICE')
-          tags['version'] = env['DD_VERSION'] if env.key?('DD_VERSION')
-          tags
+          dd_tags(env).tap do |tags|
+            tags['dd.internal.entity_id'] = env['DD_ENTITY_ID'] if env.key?('DD_ENTITY_ID')
+            tags['env'] = env['DD_ENV'] if env.key?('DD_ENV')
+            tags['service'] = env['DD_SERVICE'] if env.key?('DD_SERVICE')
+            tags['version'] = env['DD_VERSION'] if env.key?('DD_VERSION')
+          end
         end
       end
     end

--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -17,7 +17,7 @@ module Datadog
       def initialize(host, port, logger, telemetry)
         super(telemetry)
         @host = host || ENV.fetch('DD_AGENT_HOST', DEFAULT_HOST)
-        @port = port || ENV.fetch('DD_DOGSTATSD_PORT', DEFAULT_PORT)
+        @port = port || ENV.fetch('DD_DOGSTATSD_PORT', DEFAULT_PORT).to_i
         @logger = logger
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'stringio'
 require 'logger'
 require 'faker'
 require 'allocation_stats' if RUBY_VERSION >= '2.3.0'
+require 'climate_control'
 
 Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each { |f| require f }
 Dir[File.join(File.dirname(__FILE__), '/matchers/**/*.rb')].each { |f| require f }

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -143,5 +143,77 @@ describe Datadog::Statsd::Serialization::TagSerializer do
         expect(subject.format(['name:foobarfoo'.freeze])).to eq 'name:foobarfoo'
       end
     end
+
+    context '[testing management of env vars]' do
+      context 'when testing DD_TAGS' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_TAGS' => 'ghi,team:qa'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds individual tags' do
+          expect(subject.format([])).to eq 'ghi,team:qa'
+        end
+      end
+
+      context 'when testing DD_ENTITY_ID' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_ENTITY_ID' => '04652bb7-19b7-11e9-9cc6-42010a9c016d'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds the entity_id tag' do
+          expect(subject.format([])).to eq 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
+        end
+      end
+
+      context 'when testing DD_ENV' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_ENV' => 'staging'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds the env tag' do
+          expect(subject.format([])).to eq 'env:staging'
+        end
+      end
+
+      context 'when testing DD_SERVICE' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_SERVICE' => 'billing-service'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds the service tag' do
+          expect(subject.format([])).to eq 'service:billing-service'
+        end
+      end
+
+      context 'when testing DD_VERSION' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_VERSION' => '0.1.0-alpha'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds the version tag' do
+          expect(subject.format([])).to eq 'version:0.1.0-alpha'
+        end
+      end
+    end
   end
 end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -93,7 +93,7 @@ describe Datadog::Statsd do
       end
 
       it 'sets the entity tag using ' do
-        expect(subject.tags.sort).to eq [
+        expect(subject.tags).to match_array [
           'abc',
           'def',
           'ghi',
@@ -102,7 +102,7 @@ describe Datadog::Statsd do
           'team:qa',
           'version:0.1.0-alpha',
           'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
-        ].sort
+        ]
       end
     end
 


### PR DESCRIPTION
This pull request adds global tags for:

- `DD_TAGS` (acts as base set of global tags, overridden by other tags)
- `DD_ENV` --> `env:<env name>`
- `DD_SERVICE` --> `service:<service name>`
- `DD_VERSION` --> `version:<version string>`

Precedence in order from most to least preferred is manually defined global tags (via `#initialize`), `DD_ENV`/`DD_SERVICE`/`DD_VERSION`, then finally `DD_TAGS`.