### PR TITLE
Properly close UDPSocket before creating a new one

### DIFF
--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -9,7 +9,12 @@ module Datadog
 
       # Close the underlying socket
       def close
-        @socket && @socket.close
+        begin
+          @socket && @socket.close
+        rescue StandardError => boom
+          logger.error { "Statsd: #{boom.class} #{boom}" } if logger
+        end
+        @socket = nil
       end
 
       def write(payload)
@@ -33,7 +38,7 @@ module Datadog
            boom.is_a?(IOError) && boom.message =~ /closed stream/i)
           retries += 1
           begin
-            @socket = connect
+            close
             retry
           rescue StandardError => e
             boom = e


### PR DESCRIPTION
Unless you properly call `close()` on the UDPSocket object, unclosed
sockets will very quickly accumulate. If you are sending stats to
StatsD quickly, then you may actually run out of free ports. This
changes the retry behavior to close the port before trying to open a new
one.