### PR TITLE
Always append global tags, regardless if `:tags` option specified

### DIFF
--- a/lib/datadog/statsd/serialization/event_serializer.rb
+++ b/lib/datadog/statsd/serialization/event_serializer.rb
@@ -41,11 +41,10 @@ module Datadog
               end
             end
 
-            if raw_tags = options[:tags]
-              if tags = tag_serializer.format(raw_tags)
-                event << '|#'
-                event << tags
-              end
+            # also returns the global tags from serializer
+            if tags = tag_serializer.format(options[:tags])
+              event << '|#'
+              event << tags
             end
 
             if event.bytesize > MAX_EVENT_SIZE

--- a/lib/datadog/statsd/serialization/service_check_serializer.rb
+++ b/lib/datadog/statsd/serialization/service_check_serializer.rb
@@ -37,11 +37,10 @@ module Datadog
               service_check << escape_message(message)
             end
 
-            if raw_tags = options[:tags]
-              if tags = tag_serializer.format(raw_tags)
-                service_check << '|#'
-                service_check << tags
-              end
+            # also returns the global tags from serializer
+            if tags = tag_serializer.format(options[:tags])
+              service_check << '|#'
+              service_check << tags
             end
           end
         end

--- a/spec/integrations/allocation_spec.rb
+++ b/spec/integrations/allocation_spec.rb
@@ -181,11 +181,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        19
+        20
       elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        18
+        19
       else
-        17
+        18
       end
     end
 
@@ -208,11 +208,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          10
+          11
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          9
+          10
         else
-          8
+          9
         end
       end
 
@@ -250,11 +250,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        15
+        16
       elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-        14
+        15
       else
-        13
+        14
       end
     end
 
@@ -277,11 +277,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          6
+          7
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          5
+          6
         else
-          4
+          5
         end
       end
 

--- a/spec/statsd/serialization/event_serializer_spec.rb
+++ b/spec/statsd/serialization/event_serializer_spec.rb
@@ -28,6 +28,19 @@ describe Datadog::Statsd::Serialization::EventSerializer do
         .to eq '_e{15,21}:this is a title|this is a longer text'
     end
 
+    context 'when there are global tags' do
+      before do
+        allow(tag_serializer).to receive(:format).
+        with(nil).
+        and_return('a-global-tag,another-global')
+      end
+
+      it 'serializes the event correctly with global tags' do
+        expect(subject.format('this is a title', 'this is a longer text'))
+          .to eq '_e{15,21}:this is a title|this is a longer text|#a-global-tag,another-global'
+      end
+    end
+
     context 'when the event description is too long (> 8KB)' do
       it 'raises a specific error' do
         expect do

--- a/spec/statsd/serialization/service_check_serializer_spec.rb
+++ b/spec/statsd/serialization/service_check_serializer_spec.rb
@@ -27,6 +27,19 @@ describe Datadog::Statsd::Serialization::ServiceCheckSerializer do
       expect(subject.format('windmill', 'grinding')).to eq '_sc|windmill|grinding'
     end
 
+    context 'when there are global tags' do
+      before do
+        allow(tag_serializer).to receive(:format).
+        with(nil).
+        and_return('a-global-tag,another-global')
+      end
+
+      it 'serializes the event correctly with global tags' do
+        expect(subject.format('windmill', 'grinding'))
+          .to eq '_sc|windmill|grinding|#a-global-tag,another-global'
+      end
+    end
+
     context 'when having a hostname' do
       it 'serializes the service check correctly' do
         expect(subject.format('windmill', 'grinding', hostname: 'amsterdam'))


### PR DESCRIPTION
Upgrading from 4.5.0 directly to 4.8.0 we noticed our simple `#event` invocation (EMPTY_OPTIONS) was not sending our global tags. With this PR we removed the guard that a `:tags` option must be present for the tags serializer to return its tags. We must call it regardless to make sure global tags are appended.

In other words, on 4.5.0:

```ruby
statsd = Datadog::Statsd.new(...)
statsd.tags
# => ["role:web", "env:development", "app:justins-party-app"]
statsd.send(:format_event, "justin-is-testing", '2020-05-07')
# => "_e{17,10}:justin-is-testing|2020-05-07|#role:web,env:development,app:justins-party-app"
```

On 4.8.0:

```ruby
statsd = Datadog::Statsd.new(...)
statsd.tags
# => ["role:web", "env:development", "app:justins-party-app"]
statsd.send(:serializer).to_event("justin-is-testing", '2020-05-07')
# => "_e{17,10}:justin-is-testing|2020-05-07"
statsd.send(:serializer).to_event("justin-is-testing", '2020-05-07', tags: [])
# => "_e{17,10}:justin-is-testing|2020-05-07|#role:web,env:development,app:justins-party-app"
```