### PR TITLE
Async IO

### DIFF
--- a/dogstatsd-ruby.gemspec
+++ b/dogstatsd-ruby.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = "dogstatsd-ruby"
   s.version = Datadog::Statsd::VERSION
 
-  s.authors = ["Rein Henrichs"]
+  s.authors = ["Rein Henrichs", "Karim Bogtob"]
 
   s.summary = "A Ruby DogStatsd client"
   s.description = "A Ruby DogStatsd client"

--- a/dogstatsd-ruby.gemspec
+++ b/dogstatsd-ruby.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors = ["Rein Henrichs"]
 
   s.summary = "A Ruby DogStatsd client"
-  s.description = "A Ruby DogStastd client"
+  s.description = "A Ruby DogStatsd client"
   s.email = "code@datadoghq.com"
 
   s.metadata = {

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -332,10 +332,6 @@ module Datadog
       forwarder.transport_type
     end
 
-    def close
-      forwarder.close
-    end
-
     private
     attr_reader :serializer
     attr_reader :forwarder

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -7,6 +7,7 @@ require_relative 'statsd/udp_connection'
 require_relative 'statsd/uds_connection'
 require_relative 'statsd/message_buffer'
 require_relative 'statsd/serialization'
+require_relative 'statsd/sender'
 require_relative 'statsd/forwarder'
 
 # = Datadog::Statsd: A DogStatsd client (https://www.datadoghq.com)
@@ -302,9 +303,13 @@ module Datadog
       forwarder.close
     end
 
+    def sync_with_outbound_io
+      forwarder.sync_with_outbound_io
+    end
+
     # Flush the buffer into the connection
-    def flush(flush_telemetry: false)
-      forwarder.flush(flush_telemetry: flush_telemetry)
+    def flush(flush_telemetry: false, sync: false)
+      forwarder.flush(flush_telemetry: flush_telemetry, sync: sync)
     end
 
     def telemetry
@@ -325,6 +330,10 @@ module Datadog
 
     def transport_type
       forwarder.transport_type
+    end
+
+    def close
+      forwarder.close
     end
 
     private

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Datadog
+  class Statsd
+    class Sender
+      def initialize(message_buffer)
+        @message_buffer = message_buffer
+      end
+
+      def flush(sync: false)
+        raise ArgumentError, 'Start sender first' unless message_queue
+
+        message_queue.push(:flush)
+
+        rendez_vous if sync
+      end
+
+      def rendez_vous
+        # Initialize and get the thread's sync queue
+        queue = (Thread.current[:statsd_sync_queue] ||= Queue.new)
+        # tell sender-thread to notify us in the current
+        # thread's queue
+        message_queue.push(queue)
+        # wait for the sender thread to send a message
+        # once the flush is done
+        queue.pop
+      end
+
+      def add(message)
+        raise ArgumentError, 'Start sender first' unless message_queue
+
+        message_queue << message
+      end
+
+      def start
+        raise ArgumentError, 'Sender already started' if message_queue
+
+        # initialize message queue for background thread
+        @message_queue = Queue.new
+        # start background thread
+        @sender_thread = Thread.new(&method(:send_loop))
+      end
+
+      def stop(join_worker: true)
+        message_queue.close if message_queue
+        sender_thread.join if sender_thread && join_worker
+      end
+
+      private
+
+      attr_reader :message_buffer
+
+      attr_reader :message_queue
+      attr_reader :sender_thread
+
+      def send_loop
+        until (message = message_queue.pop).nil? && message_queue.closed?
+          # skip if message is nil, e.g. when message_queue
+          # is empty and closed
+          next unless message
+
+          case message
+          when :flush
+            message_buffer.flush
+          when Queue
+            message.push(:go_on)
+          else
+            message_buffer.add(message)
+          end
+        end
+
+        @message_queue = nil
+        @sender_thread = nil
+      end
+    end
+  end
+end

--- a/spec/integrations/allocation_spec.rb
+++ b/spec/integrations/allocation_spec.rb
@@ -39,7 +39,7 @@ describe 'Allocations and garbage collection' do
     before do
       # warmup
       subject.increment('foobar', tags: { something: 'a value' })
-      subject.flush
+      subject.flush(sync: true)
     end
 
     let(:expected_allocations) do
@@ -55,7 +55,7 @@ describe 'Allocations and garbage collection' do
     it 'produces low amounts of garbage' do
       expect do
         subject.increment('foobar')
-        subject.flush
+        subject.flush(sync: true)
       end.to make_allocations(expected_allocations)
     end
 
@@ -83,7 +83,7 @@ describe 'Allocations and garbage collection' do
       it 'produces even lower amounts of garbage' do
         expect do
           subject.increment('foobar')
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -102,7 +102,7 @@ describe 'Allocations and garbage collection' do
       it 'produces low amounts of garbage' do
         expect do
           subject.increment('foobar', tags: { something: 'a value' }) { 1111 }
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -112,7 +112,7 @@ describe 'Allocations and garbage collection' do
     before do
       # warmup
       subject.time('foobar', tags: { something: 'a value' }) { 1111 }
-      subject.flush
+      subject.flush(sync: true)
     end
 
     let(:expected_allocations) do
@@ -128,7 +128,7 @@ describe 'Allocations and garbage collection' do
     it 'produces low amounts of garbage' do
       expect do
         subject.time('foobar') { 1111 }
-        subject.flush
+        subject.flush(sync: true)
       end.to make_allocations(expected_allocations)
     end
 
@@ -156,7 +156,7 @@ describe 'Allocations and garbage collection' do
       it 'produces even lower amounts of garbage' do
         expect do
           subject.time('foobar') { 1111 }
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -175,7 +175,7 @@ describe 'Allocations and garbage collection' do
       it 'produces low amounts of garbage' do
         expect do
           subject.time('foobar', tags: { something: 'a value' }) { 1111 }
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -185,7 +185,7 @@ describe 'Allocations and garbage collection' do
     before do
       # warmup
       subject.event('foobar', 'happening', tags: { something: 'a value' })
-      subject.flush
+      subject.flush(sync: true)
     end
 
     let(:expected_allocations) do
@@ -201,7 +201,7 @@ describe 'Allocations and garbage collection' do
     it 'produces low amounts of garbage' do
       expect do
         subject.event('foobar', 'happening')
-        subject.flush
+        subject.flush(sync: true)
       end.to make_allocations(expected_allocations)
     end
 
@@ -229,7 +229,7 @@ describe 'Allocations and garbage collection' do
       it 'produces even lower amounts of garbage' do
         expect do
           subject.event('foobar', 'happening')
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -248,7 +248,7 @@ describe 'Allocations and garbage collection' do
       it 'produces low amounts of garbage' do
         expect do
           subject.event('foobar', 'happening', tags: { something: 'a value' })
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -258,7 +258,7 @@ describe 'Allocations and garbage collection' do
     before do
       # warmup
       subject.service_check('foobar', 'happening', tags: { something: 'a value' })
-      subject.flush
+      subject.flush(sync: true)
     end
 
     let(:expected_allocations) do
@@ -274,7 +274,7 @@ describe 'Allocations and garbage collection' do
     it 'produces low amounts of garbage' do
       expect do
         subject.service_check('foobar', 'ok')
-        subject.flush
+        subject.flush(sync: true)
       end.to make_allocations(expected_allocations)
     end
 
@@ -302,7 +302,7 @@ describe 'Allocations and garbage collection' do
       it 'produces even lower amounts of garbage' do
         expect do
           subject.service_check('foobar', 'ok')
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end
@@ -321,7 +321,7 @@ describe 'Allocations and garbage collection' do
       it 'produces low amounts of garbage' do
         expect do
           subject.service_check('foobar', 'ok', tags: { something: 'a value' })
-          subject.flush
+          subject.flush(sync: true)
         end.to make_allocations(expected_allocations)
       end
     end

--- a/spec/integrations/async_sending_spec.rb
+++ b/spec/integrations/async_sending_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+
+describe 'Sending asynchronously' do
+  subject do
+    Datadog::Statsd::Sender.new(message_buffer).tap(&:start)
+  end
+
+  let(:message_buffer) do
+    instance_double(Datadog::Statsd::MessageBuffer)
+  end
+
+  after do
+    subject.stop
+  end
+
+  context 'with normal sending conditions' do
+    context 'without rendez_vous' do
+      it 'adds message to the buffer correctly' do
+        expect(message_buffer).to receive(:add).with('message 1')
+        expect(message_buffer).to receive(:add).with('message 2')
+        expect(message_buffer).to receive(:add).with('message 3')
+
+        subject.add('message 1')
+        subject.add('message 2')
+        subject.add('message 3')
+        # add delay to be sure worker thread correctly add messages
+        sleep 0.5
+      end
+    end
+
+    context 'with rendez_vous' do
+      it 'adds message to the buffer correctly' do
+        expect(message_buffer).to receive(:add).with('message 1')
+        expect(message_buffer).to receive(:add).with('message 2')
+        expect(message_buffer).to receive(:add).with('message 3')
+
+        subject.add('message 1')
+        subject.add('message 2')
+        subject.add('message 3')
+        # add delay to be sure worker thread correctly add messages
+        subject.rendez_vous
+      end
+    end
+  end
+
+  context 'under slow networking conditions' do
+    let(:expected_messages) do
+      [
+        'message 1',
+        'message 2',
+        'message 3',
+      ]
+    end
+
+    before do
+      allow(message_buffer).to receive(:add) do |message|
+        sleep 0.5
+
+        if expected_messages.include?(message)
+          expected_messages.delete(message)
+        else
+          raise "Unexpected message '#{message}'"
+        end
+
+        true
+      end
+    end
+
+    context 'without rendez_vous' do
+      it 'adds message to the buffer correctly' do
+        subject.add('message 1')
+        subject.add('message 2')
+        subject.add('message 3')
+
+        # add delay to be sure worker thread correctly add messages
+        sleep 2
+
+        expect(expected_messages).to be_empty
+      end
+    end
+
+    context 'with rendez_vous' do
+      it 'adds message to the buffer correctly' do
+        subject.add('message 1')
+        subject.add('message 2')
+        subject.add('message 3')
+        # add delay to be sure worker thread correctly add messages
+        subject.rendez_vous
+
+        expect(expected_messages).to be_empty
+      end
+    end
+
+    context 'when asking for stop of sender in the middle' do
+      context 'when joining worker' do
+        it 'finishes properly and adds all the messages to the buffer' do
+          subject.add('message 1')
+          subject.add('message 2')
+          subject.add('message 3')
+
+          subject.stop
+
+          expect(expected_messages).to be_empty
+        end
+      end
+
+      context 'when not joining worker' do
+        it 'finishes properly and adds all the messages to the buffer' do
+          subject.add('message 1')
+          subject.add('message 2')
+          subject.add('message 3')
+
+          subject.stop(join_worker: false)
+
+          sleep 2
+
+          expect(expected_messages).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/buffering_spec.rb
+++ b/spec/integrations/buffering_spec.rb
@@ -23,7 +23,7 @@ describe 'Buffering integration testing' do
   end
 
   it 'does not not send anything when the buffer is empty' do
-    subject.flush
+    subject.flush(sync: true)
 
     expect(socket.recv).to be_nil
   end
@@ -31,7 +31,7 @@ describe 'Buffering integration testing' do
   it 'sends single samples in one packet' do
     subject.increment('mycounter')
 
-    subject.flush
+    subject.flush(sync: true)
 
     expect(socket.recv[0]).to eq 'mycounter:1|c'
   end
@@ -40,6 +40,8 @@ describe 'Buffering integration testing' do
     subject.increment('mycounter')
     subject.decrement('myothercounter')
     subject.decrement('anothercounter')
+
+    subject.sync_with_outbound_io
 
     expect(socket.recv[0]).to eq("mycounter:1|c\nmyothercounter:-1|c")
     # last value is still buffered
@@ -67,9 +69,11 @@ describe 'Buffering integration testing' do
         subject.increment('mycounter')
       end
 
+      subject.sync_with_outbound_io
+
       expect(socket.recv[0]).to eq theoretical_reply.join("\n")
 
-      subject.flush
+      subject.flush(sync: true)
 
       # We increment the telemetry metrics count when we receive it, not when
       # flush. This means that the last metric (who filled the buffer and triggered a
@@ -95,7 +99,7 @@ describe 'Buffering integration testing' do
       subject.service_check('sc', 0)
       subject.event('ev', 'text')
 
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       expect(socket.recv[0]).to eq "test:1|c\ntest:-1|c\ntest:21|c\ntest:21|g\ntest:21|h\ntest:21|ms\ntest:21|s\n_sc|sc|0\n_e{2,4}:ev|text"
     end
@@ -117,21 +121,23 @@ describe 'Buffering integration testing' do
       subject.gauge('mygauge', 10)
       subject.gauge('myothergauge', 20)
 
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry("mygauge:10|g\nmyothergauge:20|g", bytes_sent: 0, packets_sent: 0, metrics: 2)
 
       subject.increment('mycounter')
 
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('mycounter:1|c', bytes_sent: 702, packets_sent: 1, metrics: 1)
 
       subject.increment('myothercounter')
 
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       subject.increment('anoothercounter')
+
+      subject.sync_with_outbound_io
 
       expect(socket.recv[0]).to eq_with_telemetry('myothercounter:1|c', bytes_sent: 687, packets_sent: 1, metrics: 1)
       # last value is still buffered
@@ -154,7 +160,7 @@ describe 'Buffering integration testing' do
         subject.service_check('sc', 0)
         subject.event('ev', 'text')
 
-        subject.flush(flush_telemetry: true)
+        subject.flush(flush_telemetry: true, sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("test:1|c\ntest:-1|c\ntest:21|c\ntest:21|g\ntest:21|h\ntest:21|ms\ntest:21|s\n_sc|sc|0\n_e{2,4}:ev|text",
           metrics: 7,

--- a/spec/integrations/live_testing_spec.rb
+++ b/spec/integrations/live_testing_spec.rb
@@ -8,22 +8,42 @@ describe 'Live testing' do
   end
 
   context 'with a real UDP socket' do
-    it 'should actually send stuff over the socket' do
-      socket = UDPSocket.new
-      host, port = 'localhost', 12345
-      socket.bind(host, port)
+    let(:host) do
+      'localhost'
+    end
 
+    let(:port) do
+      12345
+    end
+
+    let(:server_socket) do
+      UDPSocket.new
+    end
+
+    before do
+      server_socket.bind(host, port)
+    end
+
+    after do
+      server_socket.close
+    end
+
+    it 'should actually send stuff to the server socket' do
       Datadog::Statsd.open(host, port) do |statsd|
         statsd.increment('foobar')
+        statsd.flush
         statsd.count('swag', 1337)
+        statsd.flush
         statsd.timing('work', 2450)
+        statsd.flush
         statsd.gauge('capacity', 85.2)
+        statsd.flush
       end
 
-      expect(socket.recvfrom(64).first).to eq 'foobar:1|c'
-      expect(socket.recvfrom(64).first).to eq 'swag:1337|c'
-      expect(socket.recvfrom(64).first).to eq 'work:2450|ms'
-      expect(socket.recvfrom(64).first).to eq 'capacity:85.2|g'
+      expect(server_socket.recvfrom(64).first).to eq 'foobar:1|c'
+      expect(server_socket.recvfrom(64).first).to eq 'swag:1337|c'
+      expect(server_socket.recvfrom(64).first).to eq 'work:2450|ms'
+      expect(server_socket.recvfrom(64).first).to eq 'capacity:85.2|g'
     end
   end
 end

--- a/spec/integrations/telemetry_spec.rb
+++ b/spec/integrations/telemetry_spec.rb
@@ -31,7 +31,7 @@ describe 'Telemetry integration testing' do
 
     it 'does not send any telemetry' do
       subject.count("test", 21)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq 'test:21|c'
     end
@@ -68,7 +68,7 @@ describe 'Telemetry integration testing' do
 
       subject.count('test', 21)
 
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq 'test:21|c'
     end
@@ -79,7 +79,7 @@ describe 'Telemetry integration testing' do
 
       subject.count('test', 21)
 
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'test:21|c'
     end
@@ -87,39 +87,39 @@ describe 'Telemetry integration testing' do
 
   it 'handles all data type' do
     subject.increment('test', 1)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:1|c', metrics: 1, packets_sent: 0, bytes_sent: 0)
 
     subject.decrement('test', 1)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:-1|c', metrics: 1, packets_sent: 1, bytes_sent: 680)
 
     subject.count('test', 21)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:21|c', metrics: 1, packets_sent: 1, bytes_sent: 683)
 
     subject.gauge('test', 21)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:21|g', metrics: 1, packets_sent: 1, bytes_sent: 683)
 
     subject.histogram('test', 21)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:21|h', metrics: 1, packets_sent: 1, bytes_sent: 683)
 
     subject.timing('test', 21)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:21|ms', metrics: 1, packets_sent: 1, bytes_sent: 683)
 
     subject.set('test', 21)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('test:21|s', metrics: 1, packets_sent: 1, bytes_sent: 684)
 
     subject.service_check('sc', 0)
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('_sc|sc|0', metrics: 0, service_checks: 1, packets_sent: 1, bytes_sent: 683)
 
     subject.event('ev', 'text')
-    subject.flush
+    subject.flush(sync: true)
     expect(socket.recv[0]).to eq_with_telemetry('_e{2,4}:ev|text', metrics: 0, events: 1, packets_sent: 1, bytes_sent: 682)
   end
 
@@ -132,7 +132,7 @@ describe 'Telemetry integration testing' do
 
     it 'handles dropped data (resets everytime)' do
       subject.gauge('test', 21)
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       expect(subject.telemetry.metrics).to eq 0
       expect(subject.telemetry.service_checks).to eq 0
@@ -143,7 +143,7 @@ describe 'Telemetry integration testing' do
       expect(subject.telemetry.bytes_dropped).to eq 1353
 
       subject.gauge('test', 21)
-      subject.flush(flush_telemetry: true)
+      subject.flush(flush_telemetry: true, sync: true)
 
       expect(subject.telemetry.metrics).to eq 0
       expect(subject.telemetry.service_checks).to eq 0
@@ -157,7 +157,7 @@ describe 'Telemetry integration testing' do
       socket.error_on_send(nil)
 
       subject.gauge('test', 21)
-      subject.flush
+      subject.flush(sync: true)
       expect(socket.recv[0]).to eq_with_telemetry('test:21|g', metrics: 1, service_checks: 0, events: 0, packets_dropped: 1, bytes_dropped: 1356)
 
       expect(subject.telemetry.metrics).to eq 0

--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -37,6 +37,10 @@ describe Datadog::Statsd::Forwarder do
     allow(Datadog::Statsd::Telemetry)
       .to receive(:new)
       .and_return(telemetry)
+
+    allow(Datadog::Statsd::Sender)
+      .to receive(:new)
+      .and_return(sender)
   end
 
   let(:message_buffer) do
@@ -45,6 +49,10 @@ describe Datadog::Statsd::Forwarder do
 
   let(:telemetry) do
     instance_double(Datadog::Statsd::Telemetry, would_fit_in?: true)
+  end
+
+  let(:sender) do
+    instance_double(Datadog::Statsd::Sender, start: true)
   end
 
   context 'when using a host and a port' do
@@ -90,6 +98,23 @@ describe Datadog::Statsd::Forwarder do
         expect(Datadog::Statsd::UDPConnection)
           .to receive(:new)
           .with('127.0.0.1', 1234, logger: logger, telemetry: telemetry)
+
+        subject
+      end
+
+      it 'builds the sender' do
+        expect(Datadog::Statsd::Sender)
+          .to receive(:new)
+          .with(message_buffer)
+          .exactly(1)
+
+        subject
+      end
+
+      it 'starts the sender' do
+        expect(sender)
+          .to receive(:start)
+          .exactly(1)
 
         subject
       end
@@ -193,6 +218,18 @@ describe Datadog::Statsd::Forwarder do
     its(:socket_path) { is_expected.to be_nil }
 
     describe '#close' do
+      before do
+        allow(sender).to receive(:stop)
+        allow(udp_connection).to receive(:close)
+      end
+
+      it 'stops the sender' do
+        expect(sender)
+          .to receive(:stop)
+
+        subject.close
+      end
+
       it 'forwards the close message to the connection' do
         expect(udp_connection)
           .to receive(:close)
@@ -239,6 +276,23 @@ describe Datadog::Statsd::Forwarder do
         expect(Datadog::Statsd::UDSConnection)
           .to receive(:new)
           .with('/tmp/dd_socket', logger: logger, telemetry: telemetry)
+
+        subject
+      end
+
+      it 'builds the sender' do
+        expect(Datadog::Statsd::Sender)
+          .to receive(:new)
+          .with(message_buffer)
+          .exactly(1)
+
+        subject
+      end
+
+      it 'starts the sender' do
+        expect(sender)
+          .to receive(:start)
+          .exactly(1)
 
         subject
       end
@@ -342,6 +396,18 @@ describe Datadog::Statsd::Forwarder do
     its(:socket_path) { is_expected.to eq '/tmp/dd_socket' }
 
     describe '#close' do
+      before do
+        allow(sender).to receive(:stop)
+        allow(uds_connection).to receive(:close)
+      end
+
+      it 'stops the sender' do
+        expect(sender)
+          .to receive(:stop)
+
+        subject.close
+      end
+
       it 'forwards the close message to the connection' do
         expect(uds_connection)
           .to receive(:close)
@@ -390,8 +456,8 @@ describe Datadog::Statsd::Forwarder do
     end
 
     context 'when we should flush the telemetry' do
-      let(:message_buffer) do
-        instance_double(Datadog::Statsd::MessageBuffer, add: true)
+      before do
+        allow(sender).to receive(:add)
       end
 
       let(:telemetry) do
@@ -403,8 +469,8 @@ describe Datadog::Statsd::Forwarder do
         )
       end
 
-      it 'adds the message to the buffer' do
-        expect(message_buffer)
+      it 'adds the message to the sender queue' do
+        expect(sender)
           .to receive(:add)
           .with('toto')
 
@@ -412,15 +478,15 @@ describe Datadog::Statsd::Forwarder do
       end
 
       it 'adds the telemetry message' do
-        expect(message_buffer)
+        expect(sender)
           .to receive(:add)
           .with('toto')
 
-        expect(message_buffer)
+        expect(sender)
           .to receive(:add)
           .with('telemetry1')
 
-        expect(message_buffer)
+        expect(sender)
           .to receive(:add)
           .with('telemetry2')
 
@@ -434,7 +500,7 @@ describe Datadog::Statsd::Forwarder do
       end
 
       it 'adds the message to the buffer' do
-        expect(message_buffer)
+        expect(sender)
           .to receive(:add)
           .with('toto')
 

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+describe Datadog::Statsd::Sender do
+  subject do
+    described_class.new(message_buffer)
+  end
+
+  let(:message_buffer) do
+    instance_double(Datadog::Statsd::MessageBuffer)
+  end
+
+  describe '#start' do
+    after do
+      subject.stop
+    end
+
+    it 'starts a worker thread' do
+      expect do
+        subject.start
+      end.to change { Thread.list.size }.by(1)
+    end
+
+    context 'when the sender is started' do
+      before do
+        subject.start
+      end
+
+      it 'raises an ArgumentError' do
+        expect do
+          subject.start
+        end.to raise_error(ArgumentError, /Sender already started/)
+      end
+    end
+  end
+
+  describe '#stop' do
+    before do
+      subject.start
+    end
+
+    it 'stops the worker thread' do
+      expect do
+        subject.stop
+      end.to change { Thread.list.size }.by(-1)
+    end
+  end
+
+  describe '#add' do
+    context 'when the sender is not started' do
+      it 'raises an ArgumentError' do
+        expect do
+          subject.add('sample message')
+        end.to raise_error(ArgumentError, /Start sender first/)
+      end
+    end
+
+    context 'when starting and stopping' do
+      before do
+        subject.start
+      end
+
+      after do
+        subject.stop
+      end
+
+      it 'adds a message to the message buffer asynchronously (needs rendez_vous)' do
+        expect(message_buffer)
+          .to receive(:add)
+          .with('sample message')
+
+        subject.add('sample message')
+
+        subject.rendez_vous
+      end
+    end
+  end
+
+  describe '#flush' do
+    context 'when the sender is not started' do
+      it 'raises an ArgumentError' do
+        expect do
+          subject.add('sample message')
+        end.to raise_error(ArgumentError, /Start sender first/)
+      end
+    end
+
+    context 'when starting and stopping' do
+      before do
+        subject.start
+      end
+
+      after do
+        subject.stop
+      end
+
+      context 'without sync mode' do
+        it 'flushes the message buffer (needs rendez_vous)' do
+          expect(message_buffer)
+            .to receive(:flush)
+
+          subject.flush
+          subject.rendez_vous
+        end
+      end
+
+      context 'with sync mode' do
+        it 'flushes the message buffer and waits (no explicit rendez_vous)' do
+          expect(message_buffer)
+            .to receive(:flush)
+
+          subject.flush(sync: true)
+        end
+      end
+    end
+  end
+end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -238,13 +238,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'foobar:1|c' do
       let(:basic_action) do
         subject.increment('foobar', tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the increment' do
       subject.increment('foobar')
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('foobar:1|c')
     end
@@ -256,7 +256,7 @@ describe Datadog::Statsd do
 
       it 'formats the message according to the statsd spec' do
         subject.increment('foobar', sample_rate: 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1|c|@0.5'
       end
@@ -269,7 +269,7 @@ describe Datadog::Statsd do
 
       it 'sends the increment with the sample rate' do
         subject.increment('foobar', 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1|c|@0.5'
       end
@@ -278,7 +278,7 @@ describe Datadog::Statsd do
     context 'with a increment by' do
       it 'increments by the number given' do
         subject.increment('foobar', by: 5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:5|c'
       end
@@ -293,13 +293,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'foobar:-1|c' do
       let(:basic_action) do
         subject.decrement('foobar', tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the decrement' do
       subject.decrement('foobar')
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'foobar:-1|c'
     end
@@ -311,7 +311,7 @@ describe Datadog::Statsd do
 
       it 'sends the decrement with the sample rate' do
         subject.decrement('foobar', sample_rate: 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:-1|c|@0.5'
       end
@@ -324,7 +324,7 @@ describe Datadog::Statsd do
 
       it 'sends the decrement with the sample rate' do
         subject.decrement('foobar', 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:-1|c|@0.5'
       end
@@ -333,7 +333,7 @@ describe Datadog::Statsd do
     context 'with a decrement by' do
       it 'decrements by the number given' do
         subject.decrement('foobar', by: 5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:-5|c'
       end
@@ -348,13 +348,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'foobar:123|c' do
       let(:basic_action) do
         subject.count('foobar', 123, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the count' do
       subject.count('foobar', 123)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'foobar:123|c'
     end
@@ -366,7 +366,7 @@ describe Datadog::Statsd do
 
       it 'sends the count with sample rate' do
         subject.count('foobar', 123, 0.1)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:123|c|@0.1'
       end
@@ -381,25 +381,25 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'begrutten-suffusion:536|g' do
       let(:basic_action) do
         subject.gauge('begrutten-suffusion', 536, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the gauge' do
       subject.gauge('begrutten-suffusion', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g'
     end
 
     it 'sends the gauge with sequential values' do
       subject.gauge('begrutten-suffusion', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g'
 
       subject.gauge('begrutten-suffusion', -107.3)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:-107.3|g', bytes_sent: 697, packets_sent: 1
     end
@@ -411,7 +411,7 @@ describe Datadog::Statsd do
 
       it 'sends the gauge with the sample rate' do
         subject.gauge('begrutten-suffusion', 536, sample_rate: 0.1)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
@@ -424,7 +424,7 @@ describe Datadog::Statsd do
 
       it 'formats the message according to the statsd spec' do
         subject.gauge('begrutten-suffusion', 536, 0.1)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
@@ -439,25 +439,25 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'ohmy:536|h' do
       let(:basic_action) do
         subject.histogram('ohmy', 536, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the histogram' do
       subject.histogram('ohmy', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'ohmy:536|h'
     end
 
     it 'sends the histogram with sequential values' do
       subject.histogram('ohmy', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'ohmy:536|h'
 
       subject.histogram('ohmy', -107.3)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'ohmy:-107.3|h', bytes_sent: 682, packets_sent: 1
     end
@@ -469,7 +469,7 @@ describe Datadog::Statsd do
 
       it 'sends the histogram with the sample rate' do
         subject.gauge('begrutten-suffusion', 536, sample_rate: 0.1)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
@@ -484,13 +484,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'myset:536|s' do
       let(:basic_action) do
         subject.set('myset', 536, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the set' do
       subject.set('my.set', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'my.set:536|s'
     end
@@ -502,7 +502,7 @@ describe Datadog::Statsd do
 
       it 'sends the set with the sample rate' do
         subject.set('my.set', 536, sample_rate: 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'my.set:536|s|@0.5'
       end
@@ -515,7 +515,7 @@ describe Datadog::Statsd do
 
       it 'sends the set with the sample rate' do
         subject.set('my.set', 536, 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'my.set:536|s|@0.5'
       end
@@ -530,13 +530,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'foobar:500|ms' do
       let(:basic_action) do
         subject.timing('foobar', 500, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the timing' do
       subject.timing('foobar', 500)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'foobar:500|ms'
     end
@@ -548,7 +548,7 @@ describe Datadog::Statsd do
 
       it 'sends the timing with the sample rate' do
         subject.timing('foobar', 500, sample_rate: 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:500|ms|@0.5'
       end
@@ -561,7 +561,7 @@ describe Datadog::Statsd do
 
       it 'sends the timing with the sample rate' do
         subject.timing('foobar', 500, 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:500|ms|@0.5'
       end
@@ -593,7 +593,7 @@ describe Datadog::Statsd do
           allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
@@ -604,7 +604,7 @@ describe Datadog::Statsd do
           allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms'
       end
@@ -618,7 +618,7 @@ describe Datadog::Statsd do
         end rescue nil
         # rubocop:enable Lint/RescueWithoutErrorClass
 
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms'
       end
@@ -655,7 +655,7 @@ describe Datadog::Statsd do
           allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
       end
@@ -672,7 +672,7 @@ describe Datadog::Statsd do
           allow(Process).to receive(:clock_gettime).and_return(1) if Datadog::Statsd::PROCESS_TIME_SUPPORTED
         end
 
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
       end
@@ -687,13 +687,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a metrics method', 'begrutten-suffusion:536|d' do
       let(:basic_action) do
         subject.distribution('begrutten-suffusion', 536, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends the distribution' do
       subject.distribution('begrutten-suffusion', 536)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|d'
     end
@@ -705,7 +705,7 @@ describe Datadog::Statsd do
 
       it 'sends the set with the sample rate' do
         subject.distribution('begrutten-suffusion', 536, sample_rate: 0.5)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|d|@0.5'
       end
@@ -725,13 +725,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a taggable method', '_e{15,21}:this is a title|this is a longer text', metrics: 0, events: 1 do
       let(:basic_action) do
         subject.event(title, text, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends events with title and text' do
       subject.event(title, text)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('_e{15,21}:this is a title|this is a longer text', metrics: 0, events: 1)
     end
@@ -742,7 +742,7 @@ describe Datadog::Statsd do
 
       it 'sends events with title and text' do
         subject.event(title, text)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_e{16,22}:this is a\ntitle|this is a longer\ntext', metrics: 0, events: 1)
       end
@@ -751,7 +751,7 @@ describe Datadog::Statsd do
     context 'with a known alert type' do
       it 'sends events with title and text along with a tag for the alert type' do
         subject.event(title, text, alert_type: 'warning')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_e{15,21}:this is a title|this is a longer text|t:warning', metrics: 0, events: 1)
       end
@@ -760,7 +760,7 @@ describe Datadog::Statsd do
     context 'with an unknown alert type' do
       it 'sends events with title and text along with a tag for the alert type' do
         subject.event(title, text, alert_type: 'yolo')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_e{15,21}:this is a title|this is a longer text|t:yolo', metrics: 0, events: 1)
       end
@@ -769,7 +769,7 @@ describe Datadog::Statsd do
     context 'with a known priority' do
       it 'sends events with title and text along with a tag for the priority' do
         subject.event(title, text, priority: 'low')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_e{15,21}:this is a title|this is a longer text|p:low', metrics: 0, events: 1)
       end
@@ -778,7 +778,7 @@ describe Datadog::Statsd do
     context 'with an unknown priority' do
       it 'sends events with title and text along with a tag for the priority' do
         subject.event(title, text, priority: 'yolo')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_e{15,21}:this is a title|this is a longer text|p:yolo', metrics: 0, events: 1)
       end
@@ -787,7 +787,7 @@ describe Datadog::Statsd do
     context 'with a timestamp event date' do
       it 'sends events with title and text along with a date timestamp' do
         subject.event(title, text, date_happened: timestamp)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|d:#{timestamp}", metrics: 0, events: 1)
       end
@@ -796,7 +796,7 @@ describe Datadog::Statsd do
     context 'with a string event date' do
       it 'sends events with title and text along with a date timestamp' do
         subject.event(title, text, date_happened: timestamp.to_s)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|d:#{timestamp}", metrics: 0, events: 1)
       end
@@ -805,7 +805,7 @@ describe Datadog::Statsd do
     context 'with a hostname' do
       it 'sends events with title and text along with a hostname' do
         subject.event(title, text, hostname: 'chihiro')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|h:chihiro", metrics: 0, events: 1)
       end
@@ -814,7 +814,7 @@ describe Datadog::Statsd do
     context 'with an aggregation key' do
       it 'sends events with title and text along with the aggregation key' do
         subject.event(title, text, aggregation_key: 'key 1')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|k:key 1", metrics: 0, events: 1)
       end
@@ -823,7 +823,7 @@ describe Datadog::Statsd do
     context 'with an source type name' do
       it 'sends events with title and text along with the source type name' do
         subject.event(title, text, source_type_name: 'source 1')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|s:source 1", metrics: 0, events: 1)
       end
@@ -832,7 +832,7 @@ describe Datadog::Statsd do
     context 'with several parameters (hostname, alert_type, priority, source)' do
       it 'sends events with title and text along with all the parameters' do
         subject.event(title, text, hostname: 'myhost', alert_type: 'warning', priority: 'low', source_type_name: 'source')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_e{15,21}:this is a title|this is a longer text|h:myhost|p:low|s:source|t:warning", metrics: 0, events: 1)
       end
@@ -852,13 +852,13 @@ describe Datadog::Statsd do
     it_behaves_like 'a taggable method', '_sc|windmill|grinding', metrics: 0, service_checks: 1 do
       let(:basic_action) do
         subject.service_check(name, status, tags: action_tags)
-        subject.flush
+        subject.flush(sync: true)
       end
     end
 
     it 'sends service check with name and status' do
       subject.service_check(name, status)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('_sc|windmill|grinding', metrics: 0, service_checks: 1)
     end
@@ -866,7 +866,7 @@ describe Datadog::Statsd do
     context 'with hostname' do
       it 'sends service check with name and status along with hostname' do
         subject.service_check(name, status, hostname: 'amsterdam')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_sc|windmill|grinding|h:amsterdam', metrics: 0, service_checks: 1)
       end
@@ -875,7 +875,7 @@ describe Datadog::Statsd do
     context 'with message' do
       it 'sends service check with name and status along with message' do
         subject.service_check(name, status, message: 'the wind is rising')
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry('_sc|windmill|grinding|m:the wind is rising', metrics: 0, service_checks: 1)
       end
@@ -884,7 +884,7 @@ describe Datadog::Statsd do
     context 'with integer timestamp' do
       it 'sends service check with name and status along with timestamp' do
         subject.service_check(name, status, timestamp: timestamp)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_sc|windmill|grinding|d:#{timestamp}", metrics: 0, service_checks: 1)
       end
@@ -893,7 +893,7 @@ describe Datadog::Statsd do
     context 'with string timestamp' do
       it 'sends service check with name and status along with timestamp' do
         subject.service_check(name, status, timestamp: timestamp.to_s)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_sc|windmill|grinding|d:#{timestamp}", metrics: 0, service_checks: 1)
       end
@@ -902,7 +902,7 @@ describe Datadog::Statsd do
     context 'with several parameters (hostname, message, timestamp)' do
       it 'sends service check with name and status along with all parameters' do
         subject.service_check(name, status, hostanme: 'amsterdam', message: 'the wind is rising', timestamp: timestamp.to_s)
-        subject.flush
+        subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry("_sc|windmill|grinding|d:#{timestamp}|m:the wind is rising", metrics: 0, service_checks: 1)
       end
@@ -913,7 +913,7 @@ describe Datadog::Statsd do
     before do
       # do some writing so the socket is opened
       subject.increment('lol')
-      subject.flush
+      subject.flush(sync: true)
     end
 
     it 'closes the socket' do
@@ -933,14 +933,14 @@ describe Datadog::Statsd do
       o = double('a stat', to_s: 'yolo')
 
       subject.increment(o)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('yolo:1|c')
     end
 
     it 'accepts a class name as a stat name' do
       subject.increment(Object)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('Object:1|c')
     end
@@ -948,21 +948,21 @@ describe Datadog::Statsd do
     it 'replaces Ruby constants delimeter with graphite package name' do
       class Datadog::Statsd::SomeClass; end
       subject.increment(Datadog::Statsd::SomeClass)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'Datadog.Statsd.SomeClass:1|c'
     end
 
     it 'replaces statsd reserved chars in the stat name' do
       subject.increment('ray@hostname.blah|blah.blah:blah')
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'ray_hostname.blah_blah.blah_blah:1|c'
     end
 
     it 'works with frozen strings' do
       subject.increment('some-stat'.freeze)
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry('some-stat:1|c')
     end
@@ -976,21 +976,21 @@ describe Datadog::Statsd do
 
     it 'replaces reserved chars for tags' do
       subject.increment('stat', tags: ['name:foo,bar|foo'])
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'stat:1|c|#name:foobarfoo'
     end
 
     it 'handles the cases when some tags are frozen strings' do
       subject.increment('stat', tags: ['first_tag'.freeze, 'second_tag'])
-      subject.flush
+      subject.flush(sync: true)
     end
 
     it 'converts all values to strings' do
       tag = double('a tag', to_s: 'yolo')
 
       subject.increment('stat', tags: [tag])
-      subject.flush
+      subject.flush(sync: true)
 
       expect(socket.recv[0]).to eq_with_telemetry 'stat:1|c|#yolo'
     end


### PR DESCRIPTION
### What does this PR do?

It adds a new Sender class that does asynchronous IO management and wraps the message buffer usage by the forwarder.

This new Sender class allows to set-up rendez-vous with the worker IO queue. It is useful when testing the library.

### Motivation

Asynchronous IO is nice so that we don't do IO in the hot paths of the library's users.