### PR TITLE
Performance improvements to TagSerializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ if RUBY_VERSION >= '2.3.0'
 end
 
 group :development do
+  gem 'benchmark-ips'
+  gem 'benchmark-memory'
   gem 'faker'
   gem 'rspec'
   gem 'rspec-its'

--- a/spec/integrations/allocation_spec.rb
+++ b/spec/integrations/allocation_spec.rb
@@ -44,11 +44,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        17
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         16
-      else
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         15
+      else
+        14
       end
     end
 
@@ -72,11 +72,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          9
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           8
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           7
+        else
+          6
         end
       end
 
@@ -93,9 +93,9 @@ describe 'Allocations and garbage collection' do
         if RUBY_VERSION < '2.4.0'
           25
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          24
-        else
           23
+        else
+          22
         end
       end
 
@@ -117,11 +117,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        17
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         16
-      else
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         15
+      else
+        14
       end
     end
 
@@ -145,11 +145,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          9
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           8
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           7
+        else
+          6
         end
       end
 
@@ -166,9 +166,9 @@ describe 'Allocations and garbage collection' do
         if RUBY_VERSION < '2.4.0'
           25
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          24
-        else
           23
+        else
+          22
         end
       end
 
@@ -190,11 +190,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        19
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         18
-      else
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         17
+      else
+        16
       end
     end
 
@@ -218,11 +218,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          11
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           10
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           9
+        else
+          8
         end
       end
 
@@ -239,9 +239,9 @@ describe 'Allocations and garbage collection' do
         if RUBY_VERSION < '2.4.0'
           27
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          26
-        else
           25
+        else
+          24
         end
       end
 
@@ -263,11 +263,11 @@ describe 'Allocations and garbage collection' do
 
     let(:expected_allocations) do
       if RUBY_VERSION < '2.4.0'
-        15
-      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         14
-      else
+      elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
         13
+      else
+        12
       end
     end
 
@@ -291,11 +291,11 @@ describe 'Allocations and garbage collection' do
 
       let(:expected_allocations) do
         if RUBY_VERSION < '2.4.0'
-          7
-        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           6
-        else
+        elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
           5
+        else
+          4
         end
       end
 
@@ -312,9 +312,9 @@ describe 'Allocations and garbage collection' do
         if RUBY_VERSION < '2.4.0'
           23
         elsif RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
-          22
-        else
           21
+        else
+          20
         end
       end
 


### PR DESCRIPTION
While profiling the [`ddtrace`](https://github.com/DataDog/dd-trace-rb) gem, we noticed that enabling [runtime metrics](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md#metrics), which uses `dogstatsd-ruby`, caused some performance degradation.

Running a small Rails application under [ruby-prof](https://ruby-prof.github.io/) showed us that the `TagSerializer` and `StatSerializer` were responsible for most of the time spend on `dogstatsd-ruby` calls.

This PR improves the wall time and memory usage of the `TagSerializer`.

The largest gains came from processing the provided `message_tags` in a single pass and by caching a serialized version of the global tags.

I've added a benchmark test to `tag_serializer_spec.rb` that allows one to replicate my results. This required the addition of benchmark-related gems to the `:development` group. 

### Benchmark results

A detailed explanation of all benchmarked categories:

1.  **no tags**: no global tags nor argument tags
1.  **global tags**: only global tags, no argument tags
1.  **tags Array**: only argument tags, as an array object; no global tags
1.  **tags Array + global tags**: argument tags, as an array object, with global tags
1.  **tags Hash**: only argument tags, as a hash object; no global tags
1.  **tags Hash + global tags**: argument tags, as a hash object, with global tags

#### Before this change

```
Calculating -------------------------------------
             no tags     12.608M (± 1.2%) i/s -     63.543M in   5.040483s
         global tags      2.146M (± 1.7%) i/s -     10.825M in   5.044554s
          tags Array    578.551k (± 1.4%) i/s -      2.912M in   5.033544s
           tags Hash    357.388k (± 1.7%) i/s -      1.799M in   5.035976s
tags Array + global tags
                        516.454k (± 2.0%) i/s -      2.628M in   5.091344s
tags Hash + global tags
                        334.824k (± 1.8%) i/s -      1.686M in   5.037281s

Comparison:
             no tags: 12608244.2 i/s
         global tags:  2146444.1 i/s - 5.87x  (± 0.00) slower
          tags Array:   578551.3 i/s - 21.79x  (± 0.00) slower
tags Array + global tags:   516453.9 i/s - 24.41x  (± 0.00) slower
           tags Hash:   357387.6 i/s - 35.28x  (± 0.00) slower
tags Hash + global tags:   334824.1 i/s - 37.66x  (± 0.00) slower

.Calculating -------------------------------------
             no tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         global tags   168.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
          tags Array   368.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
           tags Hash   728.000  memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
tags Array + global tags
                       416.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
tags Hash + global tags
                       776.000  memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)

Comparison:
             no tags:          0 allocated
         global tags:        168 allocated - Infx more
          tags Array:        368 allocated - Infx more
tags Array + global tags:        416 allocated - Infx more
           tags Hash:        728 allocated - Infx more
tags Hash + global tags:        776 allocated - Infx more
```

#### After this change

```
Calculating -------------------------------------
             no tags     19.240M (± 1.3%) i/s -     97.968M in   5.092676s
         global tags     18.060M (± 1.3%) i/s -     91.859M in   5.087262s
          tags Array    636.860k (± 1.4%) i/s -      3.209M in   5.039865s
           tags Hash    429.507k (± 1.8%) i/s -      2.188M in   5.097028s
tags Array + global tags
                        534.067k (± 1.6%) i/s -      2.683M in   5.024473s
tags Hash + global tags
                        383.639k (± 1.3%) i/s -      1.942M in   5.063872s

Comparison:
             no tags: 19240289.1 i/s
         global tags: 18059975.6 i/s - 1.07x  (± 0.00) slower
          tags Array:   636860.1 i/s - 30.21x  (± 0.00) slower
tags Array + global tags:   534066.8 i/s - 36.03x  (± 0.00) slower
           tags Hash:   429507.0 i/s - 44.80x  (± 0.00) slower
tags Hash + global tags:   383639.4 i/s - 50.15x  (± 0.00) slower

.Calculating -------------------------------------
             no tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         global tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
          tags Array   328.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
           tags Hash   568.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
tags Array + global tags
                       368.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
tags Hash + global tags
                       608.000  memsize (     0.000  retained)
                        12.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)

Comparison:
             no tags:          0 allocated
         global tags:          0 allocated - same
          tags Array:        328 allocated - Infx more
tags Array + global tags:        368 allocated - Infx more
           tags Hash:        568 allocated - Infx more
tags Hash + global tags:        608 allocated - Infx more
```

#### Results

| Wall time | % improvement |
| --- | --- |
| no tags	                    | 34.4% |
| global tags	                | 88.1% |
| tags Array	                 | 9.1% |
| tags Hash	                | 16.7% |
| tags Array + global tags     | 3.2% |
| tags Hash + global tags	    | 12.7% |

| Memory (bytes allocated) | % improvement |
| --- | --- |
| no tags	                      | 0.0% |
| global tags	                | 100.0% |
| tags Array	                 | 10.8% |
| tags Array + global tags	 | 11.5% |
| tags Hash	                 | 21.9% |
| tags Hash + global tags	     | 21.6% |
