### PR TITLE
Performance improvements to StatSerializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ if RUBY_VERSION >= '2.3.0'
 end
 
 group :development do
+  gem 'benchmark-ips'
+  gem 'benchmark-memory'
   gem 'faker'
   gem 'rspec'
   gem 'rspec-its'


### PR DESCRIPTION
Similar to #155, this PR reduces the overhead of submitting metrics by `dogstatsd-ruby`.

Most of the gains came from avoiding successive string resizing performed by [String#<<](https://ruby-doc.org/core-2.6/String.html#method-i-3C-3C).

Another large gain came from replacing `string.dup.gsub!` with `string.gsub` in `#formated_name`:
```ruby
require 'benchmark/ips'
a = "abc"
Benchmark.ips do |x|
  x.report('gsub') { a.gsub('a', 'z') }
  x.report('dup.gsub!') { a.dup.gsub!('a', 'z') }
  x.compare!
end

# Comparison:
#        gsub:  1600766.3 i/s
#   dup.gsub!:  1091421.3 i/s - 1.47x  (± 0.00) slower
```

A smaller gain came from removing the use of `tap` in two locations:
```ruby
require 'benchmark/ips'
Benchmark.ips do |x|
  x.report('inline') do
    s = "abc"
    s.tr!('a', 'z')
    s
  end
  x.report('tap') do
    "abc".tap { |s| s.tr!('a', 'z') }
  end
  x.compare!
end

# Comparison:
#   inline:  4300892.6 i/s
#      tap:  3601127.4 i/s - 1.19x  (± 0.00) slower
```

There were no memory improvements performed.

### Benchmark results

#### Before

```
Calculating -------------------------------------
             no tags     822.563k (± 1.9%) i/s -      4.159M in   5.058459s
no tags + sample rate    557.104k (± 1.7%) i/s -      2.800M in   5.027398s
           with tags     290.806k (± 1.9%) i/s -      1.474M in   5.070795s
with tags + sample rate  248.824k (± 1.9%) i/s -      1.254M in   5.040946s

Comparison:
                no tags:   822563.2 i/s
  no tags + sample rate:   557104.3 i/s - 1.48x  (± 0.00) slower
              with tags:   290805.8 i/s - 2.83x  (± 0.00) slower
with tags + sample rate:   248823.6 i/s - 3.31x  (± 0.00) slower
```

#### After

```
Calculating -------------------------------------
             no tags       1.098M (± 1.4%) i/s -      5.526M in   5.036068s
no tags + sample rate    707.986k (± 1.3%) i/s -      3.579M in   5.055567s
           with tags     325.535k (± 2.9%) i/s -      1.629M in   5.009379s
with tags + sample rate  275.804k (± 2.6%) i/s -      1.386M in   5.027488s

Comparison:
                no tags:  1097525.6 i/s
  no tags + sample rate:   707986.2 i/s - 1.55x  (± 0.00) slower
              with tags:   325534.7 i/s - 3.37x  (± 0.00) slower
with tags + sample rate:   275803.8 i/s - 3.98x  (± 0.00) slower
```

#### Results

| Wall time | % improvement |
| --- | --- |
| no tags                   | 33.4% |
| no tags + sample rate     | 27.0% |
| with tags	                | 11.9% |
| with tags + sample rate   | 10.8% |
