### PR TITLE
Introduce truncate_if_too_long option to allow users to send too long events

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -290,6 +290,7 @@ module Datadog
     # @option opts [String, nil] :priority ('normal') Can be "normal" or "low"
     # @option opts [String, nil] :source_type_name (nil) Assign a source type to the event
     # @option opts [String, nil] :alert_type ('info') Can be "error", "warning", "info" or "success".
+    # @option opts [Boolean, false] :truncate_if_too_long (false) Truncate the event if it is too long
     # @option opts [Array<String>] :tags tags to be added to every metric
     # @example Report an awful event:
     #   $statsd.event('Something terrible happened', 'The end is near if we do nothing', :alert_type=>'warning', :tags=>['end_of_times','urgent'])

--- a/lib/datadog/statsd/serialization/event_serializer.rb
+++ b/lib/datadog/statsd/serialization/event_serializer.rb
@@ -48,7 +48,11 @@ module Datadog
             end
 
             if event.bytesize > MAX_EVENT_SIZE
-              raise "Event #{title} payload is too big (more that 8KB), event discarded"
+              if options[:truncate_if_too_long]
+                event.slice!(MAX_EVENT_SIZE..event.length)
+              else
+                raise "Event #{title} payload is too big (more that 8KB), event discarded"
+              end
             end
           end
         end

--- a/spec/statsd/serialization/event_serializer_spec.rb
+++ b/spec/statsd/serialization/event_serializer_spec.rb
@@ -47,6 +47,15 @@ describe Datadog::Statsd::Serialization::EventSerializer do
           subject.format('this is a title', 'this is a longer text' * 1000)
         end.to raise_error(RuntimeError, /payload is too big/)
       end
+
+      context 'when the truncate_if_too_long option is true' do
+        let(:options) { { truncate_if_too_long: true } }
+
+        it 'truncates the overage' do
+          expect(subject.format('this is a title', 'this is a longer text' * 1000, options).bytesize)
+            .to eq Datadog::Statsd::MAX_EVENT_SIZE
+        end
+      end
     end
 
     context 'when having an alert type' do

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -666,6 +666,16 @@ describe Datadog::Statsd do
           subject.event(title, text)
         end.to raise_error(RuntimeError, /payload is too big/)
       end
+
+      context 'when truncate_if_too_long option is specified' do
+        let(:options) { { truncate_if_too_long: true } }
+
+        it 'does not raise error' do
+          expect do
+            subject.event(title, text, options)
+          end.not_to raise_error(RuntimeError, /payload is too big/)
+        end
+      end
     end
 
     context 'with a known alert type' do


### PR DESCRIPTION
Dear maintainers,

Through the operation, we have been getting that event exceeding the message length limit exception.
I believe it is not a bad choice for the library to prepare the arbitrary option to truncate event length for users.

Looks already C# provides that option as a library.
So that I propose to introduce the same option to the ruby gem.
https://github.com/DataDog/dogstatsd-csharp-client/pull/22/files

This is just a proposal PR so I don't mind modifying or making an official PR to introduce this feature.
Please let me know what you think.

Thanks!