### PR TITLE
Automatically set the socket to the value of DD_DOGSTATSD_SOCKET

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -78,11 +78,10 @@ module Datadog
     def initialize(
       host = nil,
       port = nil,
-      socket_path: nil,
+      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
 
       namespace: nil,
       tags: nil,
-      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
       sample_rate: nil,
 
       buffer_max_payload_size: nil,

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -82,6 +82,7 @@ module Datadog
 
       namespace: nil,
       tags: nil,
+      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
       sample_rate: nil,
 
       buffer_max_payload_size: nil,

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -104,6 +104,20 @@ describe Datadog::Statsd do
           'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
         ]
       end
+
+      context 'when the socket environment variable is set' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_DOGSTATSD_SOCKET' => '/some/socket',
+          ) do
+            example.run
+          end
+        end
+
+        it 'sets the socket to the environment variables value' do
+          expect(subject.connection.socket_path).to eq '/some/socket'
+        end
+      end
     end
 
     context 'when using default values' do


### PR DESCRIPTION
This PR changes `Datadog::Statsd.new` default behaviour to by default set `socket_path` to the value of the `DD_DOGSTATSD_SOCKET` environment variable.

We are in the process of  moving from using UDP to using UDS and this helps in that move by allowing us to control this without updating all the applications setup of dogstatsd.