### PR TITLE
Fix a warning in Ruby 2.7.2

### DIFF
--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -13,7 +13,7 @@ module Datadog
 
           # Convert to tag list and set
           @global_tags = to_tags_list(global_tags)
-          @global_tags_formatted = @global_tags.join(',') if @global_tags.any?
+          @global_tags_formatted = (@global_tags.join(',') if @global_tags.any?)
         end
 
         def format(message_tags)


### PR DESCRIPTION
Currently in `Ruby 2.7.2` this warning will show on serialization:

```
warning: instance variable @global_tags_formatted not initialized
```

This PR modifies the assignment so that instead of not happening if the
conditional is false, it assigns `nil` back to the ivar.

---

Note: If you'd like to see the warning, just set `$VERBOSE = true` in
`spec/spec_helper.rb`

Thank you!