### PR TITLE
Safely close concurrent resources on Sender

### DIFF
--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -45,12 +45,18 @@ module Datadog
 
       if CLOSEABLE_QUEUES
         def stop(join_worker: true)
+          message_queue = @message_queue
           message_queue.close if message_queue
+
+          sender_thread = @sender_thread
           sender_thread.join if sender_thread && join_worker
         end
       else
         def stop(join_worker: true)
+          message_queue = @message_queue
           message_queue << :close if message_queue
+
+          sender_thread = @sender_thread
           sender_thread.join if sender_thread && join_worker
         end
       end


### PR DESCRIPTION
We've started seeing sporadic errors during `dogstatsd-ruby` shutdown, and we've tracked it down to an unsafe concurrent resource access in `Sender#stop`:
```
       undefined method `join' for nil:NilClass
     # /usr/local/bundle/jruby/2.5.0/gems/dogstatsd-ruby-5.0.0/lib/datadog/statsd/sender.rb:49:in `stop'
```

https://github.com/DataDog/dogstatsd-ruby/blob/4c1d42df6b6ad566aed2d28ea3ce8d637cdd25f8/lib/datadog/statsd/sender.rb#L48-L49

This error happens because, in the time between the `if sender_thread` check and the `sender_thread.join` call, `Sender#send_loop` modifies that value: https://github.com/DataDog/dogstatsd-ruby/blob/4c1d42df6b6ad566aed2d28ea3ce8d637cdd25f8/lib/datadog/statsd/sender.rb#L82-L83

This PR ensures that the object we check for presence is the same object we operate on.
Both objects affected here, `Queue` (for `message_queue`) and `Thread` (for `sender_thread`), are safe to receive their respective operations a second time without side-effects.