### PR TITLE
Re-introduce the batch method in v5.x

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -299,6 +299,24 @@ module Datadog
       forwarder.send_message(serializer.to_event(title, text, opts))
     end
 
+    # Send several metrics in the same packet.
+    # They will be buffered and flushed when the block finishes.
+    #
+    # This method exists for compatibility with v4.x versions, it is not needed
+    # anymore since the batching is now automatically done internally.
+    # It also means that an automatic flush could occur if the buffer is filled
+    # during the execution of the batch block.
+    #
+    # @example Send several metrics in one packet:
+    #   $statsd.batch do |s|
+    #      s.gauge('users.online',156)
+    #      s.increment('page.views')
+    #    end
+    def batch
+      yield self
+      flush(sync: true)
+    end
+
     # Close the underlying socket
     def close
       forwarder.close

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -307,6 +307,8 @@ module Datadog
     # It also means that an automatic flush could occur if the buffer is filled
     # during the execution of the batch block.
     #
+    # This method is DEPRECATED and will be removed in future v6.x API.
+    #
     # @example Send several metrics in one packet:
     #   $statsd.batch do |s|
     #      s.gauge('users.online',156)

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -13,7 +13,11 @@ module Datadog
 
           # Convert to tag list and set
           @global_tags = to_tags_list(global_tags)
-          @global_tags_formatted = @global_tags.join(',') if @global_tags.any?
+          if @global_tags.any?
+            @global_tags_formatted = @global_tags.join(',')
+          else
+            @global_tags_formatted = nil
+          end
         end
 
         def format(message_tags)

--- a/spec/integrations/buffering_spec.rb
+++ b/spec/integrations/buffering_spec.rb
@@ -28,6 +28,20 @@ describe 'Buffering integration testing' do
     expect(socket.recv).to be_nil
   end
 
+  it 'sends multiple samples in one packet with the batch compatility method' do
+    subject.batch do |s|
+      s.increment('mycounter')
+      s.increment('myothercounter')
+      s.decrement('anothercounter')
+      s.increment('myothercounter')
+      s.decrement('yetanothercounter')
+    end
+    # multiple reads since buffer_max_pool_size == 2
+    expect(socket.recv[0]).to eq("mycounter:1|c\nmyothercounter:1|c")
+    expect(socket.recv[0]).to eq("anothercounter:-1|c\nmyothercounter:1|c")
+    expect(socket.recv[0]).to eq("yetanothercounter:-1|c")
+  end
+
   it 'sends single samples in one packet' do
     subject.increment('mycounter')
 

--- a/spec/integrations/buffering_spec.rb
+++ b/spec/integrations/buffering_spec.rb
@@ -28,7 +28,7 @@ describe 'Buffering integration testing' do
     expect(socket.recv).to be_nil
   end
 
-  it 'sends multiple samples in one packet with the batch compatility method' do
+  it 'the batch compatility method properly uses the buffer max pool size' do
     subject.batch do |s|
       s.increment('mycounter')
       s.increment('myothercounter')
@@ -65,6 +65,17 @@ describe 'Buffering integration testing' do
   context 'when testing payload size limits' do
     let(:buffer_max_pool_size) do
       nil
+    end
+
+    it 'the batch compatility method is flushing everything in one time' do
+      subject.batch do |s|
+        s.increment('mycounter')
+        s.increment('myothercounter')
+        s.decrement('anothercounter')
+        s.increment('myothercounter')
+        s.decrement('yetanothercounter')
+      end
+      expect(socket.recv[0]).to eq("mycounter:1|c\nmyothercounter:1|c\nanothercounter:-1|c\nmyothercounter:1|c\nyetanothercounter:-1|c")
     end
 
     it 'flushes when the buffer gets too big' do


### PR DESCRIPTION
To help with compatibility with v4.x version, add a `Statsd#batch` method providing nearly the same behavior as before. The difference is that an automatic flush could be triggered if the buffer is filled during the execution of the batch block. Addresses #173 

This PR also fixes a warning by always initializing the instance var global_tag_formatted in the tag serializer. Should address #174