### PR TITLE
Add flush on close

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -320,7 +320,10 @@ module Datadog
     end
 
     # Close the underlying socket
-    def close
+    #
+    # @param [Boolean, true] flush Should we flush the metrics before closing
+    def close(flush: true)
+      flush(sync: true) if flush
       forwarder.close
     end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -926,10 +926,36 @@ describe Datadog::Statsd do
       subject.flush(sync: true)
     end
 
-    it 'closes the socket' do
-      expect(socket).to receive(:close)
+    context 'when not using the flush option' do
+      it 'closes the socket' do
+        expect(socket).to receive(:close)
 
-      subject.close
+        subject.close(flush: false)
+      end
+
+      it 'does not write buffered data to the socket' do
+        subject.increment('test')
+
+        expect(socket).not_to receive(:send)
+
+        subject.close(flush: false)
+      end
+    end
+
+    context 'when using the flush option' do
+      it 'closes the socket' do
+        expect(socket).to receive(:close)
+
+        subject.close
+      end
+
+      it 'writes the buffered data to the socket' do
+        subject.increment('test')
+
+        expect(socket).to receive(:send)
+
+        subject.close
+      end
     end
   end
 


### PR DESCRIPTION
# What is this PR doing?

Adding a `flush` option to the #close method, defaulting to true so that the metrics are flushed before closing the socket.

# Motivation

Correctly flush last metrics on close. 