### PR TITLE
Add autoclose feature

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -84,6 +84,7 @@ module Datadog
       buffer_overflowing_stategy: :drop,
 
       logger: nil,
+      auto_close: false,
 
       telemetry_enable: true,
       telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL
@@ -111,6 +112,8 @@ module Datadog
 
         telemetry_flush_interval: telemetry_enable ? telemetry_flush_interval : nil,
       )
+
+      self.class.subscribe_for_close_on_exit(self) if auto_close
     end
 
     # yield a new instance to a block and close it when done
@@ -381,5 +384,24 @@ module Datadog
         forwarder.send_message(full_stat)
       end
     end
+
+    class << self
+      def subscribe_for_close_on_exit(instance)
+        instances << instance
+      end
+
+      def close_instances
+        instances.each(&:close)
+      end
+
+      private
+      def instances
+        @instances ||= []
+      end
+    end
   end
+end
+
+at_exit do
+  Datadog::Statsd.close_instances
 end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -933,6 +933,41 @@ describe Datadog::Statsd do
     end
   end
 
+  describe '.close_instances' do
+    let(:with_auto_close) do
+      described_class.new('localhost', 1234,
+        namespace: namespace,
+        sample_rate: sample_rate,
+        tags: tags,
+        logger: logger,
+        telemetry_flush_interval: -1,
+        auto_close: true,
+      )
+    end
+
+    let(:without_auto_close) do
+      described_class.new('localhost', 1234,
+        namespace: namespace,
+        sample_rate: sample_rate,
+        tags: tags,
+        logger: logger,
+        telemetry_flush_interval: -1,
+      )
+    end
+
+    it 'closes the registered instances' do
+      expect(with_auto_close).to receive(:close).and_call_original
+
+      described_class.close_instances
+    end
+
+    it 'does not close unregistered instances' do
+      expect(without_auto_close).not_to receive(:close).and_call_original
+
+      described_class.close_instances
+    end
+  end
+
   # TODO: This specs will have to move to another class (a responsibility that we will have to separate)
   describe 'Stat names' do
     let(:namespace) { nil }


### PR DESCRIPTION
# What is this PR doing?

It's adding an auto-close feature on the statsd clients so that they are correctly closed when the app exists.

# Motivation

Closing the socket when the client is closed.
Considering PR #180, it will correctly flush the last metrics on clients with this option.