### PR TITLE
sender: do not try to flush where there is no available message_queue

### DIFF
--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -10,7 +10,8 @@ module Datadog
       end
 
       def flush(sync: false)
-        raise ArgumentError, 'Start sender first' unless message_queue
+        # don't try to flush if there is no message_queue instantiated
+        return unless message_queue
 
         message_queue.push(:flush)
 


### PR DESCRIPTION
Will fix unit tests relying on the auto_close feature.