### PR TITLE
Add pry to development dependencies and enable gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gemspec
+
 gem 'rake', '>= 12.3.3'
 gem 'minitest'
 gem 'minitest-matchers'
@@ -27,6 +29,7 @@ group :development do
   gem 'rspec-its'
   gem 'timecop'
   gem 'byebug'
+  gem 'pry'
 end
 
 group :test do


### PR DESCRIPTION
Hello fellow Ruby datadog devs 👋 . I had to run a few experiments on the repository and found this tiny improvement helpful.

* [pry](https://github.com/pry/pry) is a really well-known alternative to irb. Especially compared to older versions of irb, it's really much nicer.

  We also use it in dd-trace-rb for development: <https://github.com/DataDog/dd-trace-rb/blob/50e2f8ea035b81ca8c2a156679676b76f635ff1e/Gemfile#L19>

* The second change -- adding `gemspec`, allows the in-development gem to be loaded by apps running under `bundle exec`.

  See <https://bundler.io/man/gemfile.5.html#GEMSPEC> for more details on what calling `gemspec` on the `Gemfile` does. (Also note that since the `Gemfile` is not shipped to customers -- it doesn't change anything for them, it's just nicer for development).

By combining these, we can do `bundle exec pry` (or `bundle exec irb`) to start a REPL where we can interactively
poke at the in-development version of the gem.
