### PR TITLE
Revert "Add autoclose feature"

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -84,7 +84,6 @@ module Datadog
       buffer_overflowing_stategy: :drop,
 
       logger: nil,
-      auto_close: false,
 
       telemetry_enable: true,
       telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL
@@ -112,8 +111,6 @@ module Datadog
 
         telemetry_flush_interval: telemetry_enable ? telemetry_flush_interval : nil,
       )
-
-      self.class.subscribe_for_close_on_exit(self) if auto_close
     end
 
     # yield a new instance to a block and close it when done
@@ -387,24 +384,5 @@ module Datadog
         forwarder.send_message(full_stat)
       end
     end
-
-    class << self
-      def subscribe_for_close_on_exit(instance)
-        instances << instance
-      end
-
-      def close_instances
-        instances.each(&:close)
-      end
-
-      private
-      def instances
-        @instances ||= []
-      end
-    end
   end
-end
-
-at_exit do
-  Datadog::Statsd.close_instances
 end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -959,41 +959,6 @@ describe Datadog::Statsd do
     end
   end
 
-  describe '.close_instances' do
-    let(:with_auto_close) do
-      described_class.new('localhost', 1234,
-        namespace: namespace,
-        sample_rate: sample_rate,
-        tags: tags,
-        logger: logger,
-        telemetry_flush_interval: -1,
-        auto_close: true,
-      )
-    end
-
-    let(:without_auto_close) do
-      described_class.new('localhost', 1234,
-        namespace: namespace,
-        sample_rate: sample_rate,
-        tags: tags,
-        logger: logger,
-        telemetry_flush_interval: -1,
-      )
-    end
-
-    it 'closes the registered instances' do
-      expect(with_auto_close).to receive(:close).and_call_original
-
-      described_class.close_instances
-    end
-
-    it 'does not close unregistered instances' do
-      expect(without_auto_close).not_to receive(:close).and_call_original
-
-      described_class.close_instances
-    end
-  end
-
   # TODO: This specs will have to move to another class (a responsibility that we will have to separate)
   describe 'Stat names' do
     let(:namespace) { nil }


### PR DESCRIPTION
This reverts commit cb427f61ae910d3796f64425aeffb2225e126641 , reverts PR https://github.com/DataDog/dogstatsd-ruby/pull/181

This feature is introducing way too much complexity for applications using `fork`s: since the auto-close feature use a global list to store the instances list, it could lead to a fork dying trying to close an instance which has been created before the fork.
It's not wrong, but it's complexifying the thinking process. It is better and important to manually close instances when they are not needed anymore (they create a socket and a thread, not closing the instance would leak these resources).
