### PR TITLE
Add `SingleThreadSender` to offer a single-thread mode of the DogStatsD client

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -8,6 +8,7 @@ require_relative 'statsd/uds_connection'
 require_relative 'statsd/message_buffer'
 require_relative 'statsd/serialization'
 require_relative 'statsd/sender'
+require_relative 'statsd/single_thread_sender'
 require_relative 'statsd/forwarder'
 
 # = Datadog::Statsd: A DogStatsd client (https://www.datadoghq.com)
@@ -70,6 +71,7 @@ module Datadog
     # @option [Integer] buffer_max_pool_size max messages to buffer
     # @option [String] socket_path unix socket path
     # @option [Float] default sample rate if not overridden
+    # @option [Boolean] single_thread flushes the metrics on the main thread instead of in a companion thread
     def initialize(
       host = nil,
       port = nil,
@@ -84,6 +86,8 @@ module Datadog
       buffer_overflowing_stategy: :drop,
 
       logger: nil,
+
+      single_thread: false,
 
       telemetry_enable: true,
       telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL
@@ -104,6 +108,8 @@ module Datadog
 
         global_tags: tags,
         logger: logger,
+
+        single_thread: single_thread,
 
         buffer_max_payload_size: buffer_max_payload_size,
         buffer_max_pool_size: buffer_max_pool_size,

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -18,6 +18,8 @@ module Datadog
         telemetry_flush_interval: nil,
         global_tags: [],
 
+        single_thread: false,
+
         logger: nil
       )
         @transport_type = socket_path.nil? ? :udp : :uds
@@ -53,7 +55,7 @@ module Datadog
           overflowing_stategy: buffer_overflowing_stategy,
         )
 
-        @sender = Sender.new(buffer)
+        @sender = single_thread ? SingleThreadSender.new(buffer) : Sender.new(buffer)
         @sender.start
       end
 

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -11,10 +11,7 @@ module Datadog
         @message_buffer.add(message)
       end
 
-      # We do not use the `sync` parameter since the `SingleThreadSender` is always
-      # synchronous. However, we still have it to have the same method signature
-      # with `Sender`.
-      def flush(sync: true)
+      def flush(*)
         @message_buffer.flush()
       end
 

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Datadog
+  class Statsd
+    class SingleThreadSender
+      def initialize(message_buffer)
+        @message_buffer = message_buffer
+      end
+
+      def add(message)
+        @message_buffer.add(message)
+      end
+
+      # We do not use the `sync` parameter since the `SingleThreadSender` is always
+      # synchronous. However, we still have it to have the same method signature
+      # with `Sender`.
+      def flush(sync: true)
+        @message_buffer.flush()
+      end
+
+      # Compatibility with `Sender`
+      def start()
+      end
+
+      # Compatibility with `Sender`
+      def stop()
+      end
+
+      # Compatibility with `Sender`
+      def rendez_vous()
+      end
+    end
+  end
+end

--- a/spec/integrations/buffering_spec.rb
+++ b/spec/integrations/buffering_spec.rb
@@ -2,16 +2,17 @@
 
 require 'spec_helper'
 
-describe 'Buffering integration testing' do
-  let(:socket) { FakeUDPSocket.new(copy_message: true) }
-
+RSpec.shared_examples 'Buffering integration testing' do |single_thread|
   subject do
     Datadog::Statsd.new('localhost', 1234,
       telemetry_flush_interval: -1,
       telemetry_enable: false,
+      single_thread: single_thread,
       buffer_max_pool_size: buffer_max_pool_size,
     )
   end
+  let(:socket) { FakeUDPSocket.new(copy_message: true) }
+
 
   let(:buffer_max_pool_size) do
     2
@@ -135,6 +136,7 @@ describe 'Buffering integration testing' do
       Datadog::Statsd.new('localhost', 1234,
         telemetry_flush_interval: 60,
         buffer_max_pool_size: buffer_max_pool_size,
+        single_thread: single_thread,
       )
     end
 
@@ -201,4 +203,12 @@ describe 'Buffering integration testing' do
       end
     end
   end
+end
+
+describe 'Single threaded mode' do
+  it_behaves_like 'Buffering integration testing', "true"
+end
+
+describe 'Multi threaded mode' do
+  it_behaves_like 'Buffering integration testing', "false"
 end

--- a/spec/statsd/single_thread_sender_spec.rb
+++ b/spec/statsd/single_thread_sender_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Datadog::Statsd::SingleThreadSender do
+  subject do
+    described_class.new(message_buffer)
+  end
+
+  let(:message_buffer) do
+    instance_double(Datadog::Statsd::MessageBuffer)
+  end
+
+  describe '#start' do
+    after do
+      subject.stop
+    end
+
+    it 'is not starting any thread' do
+      expect do
+        subject.start
+      end.to change { Thread.list.size }.by(0)
+    end
+  end
+
+  describe '#add' do
+    context 'when starting and stopping' do
+      before do
+        subject.start
+      end
+
+      after do
+        subject.stop
+      end
+
+      it 'adds a message to the message buffer asynchronously (needs rendez_vous)' do
+        expect(message_buffer)
+          .to receive(:add)
+          .with('sample message')
+
+        subject.add('sample message')
+      end
+    end
+  end
+
+  describe '#flush' do
+    context 'when starting and stopping' do
+      before do
+        subject.start
+      end
+
+      after do
+        subject.stop
+      end
+
+      it 'flushes the message buffer' do
+        expect(message_buffer)
+          .to receive(:flush)
+
+        subject.flush
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using the single-thread mode, the flushes are always happening synchronously
on the thread calling the metrics submissions/flush.