### PR TITLE
[sender] reset buffers on forks and reset the companion thread if dead or nil

### DIFF
--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -36,6 +36,7 @@ module Datadog
           retries += 1
           begin
             close
+            connect
             retry
           rescue StandardError => e
             boom = e

--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -8,16 +8,6 @@ module Datadog
         @logger = logger
       end
 
-      # Close the underlying socket
-      def close
-        begin
-          @socket && @socket.close if instance_variable_defined?(:@socket)
-        rescue StandardError => boom
-          logger.error { "Statsd: #{boom.class} #{boom}" } if logger
-        end
-        @socket = nil
-      end
-
       def write(payload)
         logger.debug { "Statsd: #{payload}" } if logger
 
@@ -49,12 +39,9 @@ module Datadog
       end
 
       private
+
       attr_reader :telemetry
       attr_reader :logger
-
-      def socket
-        @socket ||= connect
-      end
     end
   end
 end

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -55,7 +55,7 @@ module Datadog
           overflowing_stategy: buffer_overflowing_stategy,
         )
 
-        @sender = single_thread ? SingleThreadSender.new(buffer) : Sender.new(buffer)
+        @sender = single_thread ? SingleThreadSender.new(buffer) : Sender.new(buffer, logger: logger)
         @sender.start
       end
 

--- a/lib/datadog/statsd/message_buffer.rb
+++ b/lib/datadog/statsd/message_buffer.rb
@@ -42,13 +42,17 @@ module Datadog
         true
       end
 
+      def reset
+        buffer.clear
+        @message_count = 0
+      end
+
       def flush
         return if buffer.empty?
 
+        connection = @connection
         connection.write(buffer)
-
-        buffer.clear
-        @message_count = 0
+        reset
       end
 
       private

--- a/lib/datadog/statsd/message_buffer.rb
+++ b/lib/datadog/statsd/message_buffer.rb
@@ -50,7 +50,6 @@ module Datadog
       def flush
         return if buffer.empty?
 
-        connection = @connection
         connection.write(buffer)
         reset
       end

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -18,9 +18,9 @@ module Datadog
 
       def flush(sync: false)
         # don't try to flush if there is no message_queue instantiated
-        return unless @message_queue
+        return unless message_queue
 
-        @message_queue.push(:flush)
+        message_queue.push(:flush)
 
         rendez_vous if sync
       end
@@ -30,28 +30,28 @@ module Datadog
         queue = (Thread.current[:statsd_sync_queue] ||= Queue.new)
         # tell sender-thread to notify us in the current
         # thread's queue
-        @message_queue.push(queue)
+        message_queue.push(queue)
         # wait for the sender thread to send a message
         # once the flush is done
         queue.pop
       end
 
       def add(message)
-        raise ArgumentError, 'Start sender first' unless @message_queue
+        raise ArgumentError, 'Start sender first' unless message_queue
 
         # if the thread does not exist, we are probably running in a forked process,
         # empty the message queue (these messages belong to parent process) and spawn
         # a new companion thread.
-        if !@sender_thread.alive?
+        if !sender_thread.alive?
           @message_queue = nil
           start
         end
 
-        @message_queue << message
+        message_queue << message
       end
 
       def start
-        raise ArgumentError, 'Sender already started' if @message_queue
+        raise ArgumentError, 'Sender already started' if message_queue
 
         # initialize message queue for background thread
         @message_queue = Queue.new
@@ -79,20 +79,24 @@ module Datadog
 
       private
 
+      attr_reader :message_buffer
+      attr_reader :message_queue
+      attr_reader :sender_thread
+
       if CLOSEABLE_QUEUES
         def send_loop
-          until !@sender_thread.alive? || ((message = @message_queue.pop).nil? && @message_queue.closed?)
+          until !sender_thread.alive? || ((message = message_queue.pop).nil? && message_queue.closed?)
             # skip if message is nil, e.g. when message_queue
             # is empty and closed
             next unless message
 
             case message
             when :flush
-              @message_buffer.flush
+              message_buffer.flush
             when Queue
               message.push(:go_on)
             else
-              @message_buffer.add(message)
+              message_buffer.add(message)
             end
           end
 
@@ -102,7 +106,7 @@ module Datadog
       else
         def send_loop
           loop do
-            message = @message_queue.pop
+            message = message_queue.pop
 
             next unless message
 
@@ -110,11 +114,11 @@ module Datadog
             when :close
               break
             when :flush
-              @message_buffer.flush
+              message_buffer.flush
             when Queue
               message.push(:go_on)
             else
-              @message_buffer.add(message)
+              message_buffer.add(message)
             end
           end
 

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -85,7 +85,7 @@ module Datadog
 
       if CLOSEABLE_QUEUES
         def send_loop
-          until !sender_thread.alive? || ((message = message_queue.pop).nil? && message_queue.closed?)
+          until !Thread.current.alive? || ((message = message_queue.pop).nil? && message_queue.closed?)
             # skip if message is nil, e.g. when message_queue
             # is empty and closed
             next unless message

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -2,6 +2,13 @@
 
 module Datadog
   class Statsd
+    # Sender is using a companion thread to flush and pack messages
+    # in a `MessageBuffer`.
+    # The communication with this thread is done using a `Queue`.
+    # If the thread is dead, it is starting a new one to avoid having a blocked
+    # Sender with no companion thread to communicate with (most of the time, having
+    # a dead companion thread means that a fork just happened and that we are
+    # running in the child process).
     class Sender
       CLOSEABLE_QUEUES = Queue.instance_methods.include?(:close)
 

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -35,16 +35,12 @@ module Datadog
         # if the thread does not exist, we are probably running in a forked process,
         # empty the message queue (these messages belong to parent process) and spawn
         # a new companion thread.
-        if is_companion_thread_dead?
+        if !@sender_thread.alive?
           @message_queue = nil
           start
         end
 
         @message_queue << message
-      end
-
-      def is_companion_thread_dead?
-        return @sender_thread == nil || @sender_thread.status == false || @sender_thread.status == 'dead'
       end
 
       def start
@@ -78,7 +74,7 @@ module Datadog
 
       if CLOSEABLE_QUEUES
         def send_loop
-          until is_companion_thread_dead? || ((message = @message_queue.pop).nil? && @message_queue.closed?)
+          until !@sender_thread.alive? || ((message = @message_queue.pop).nil? && @message_queue.closed?)
             # skip if message is nil, e.g. when message_queue
             # is empty and closed
             next unless message

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -39,6 +39,8 @@ module Datadog
       def rendez_vous()
       end
 
+      private
+
       # below are "fork management" methods to be able to clean the MessageBuffer
       # if it detects that it is running in a unknown PID.
 

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -2,6 +2,10 @@
 
 module Datadog
   class Statsd
+    # The SingleThreadSender is a sender synchronously buffering messages
+    # in a `MessageBuffer`.
+    # It is using current Process.PID to check it is the result of a recent fork
+    # and it is reseting the MessageBuffer if that's the case.
     class SingleThreadSender
       def initialize(message_buffer)
         @message_buffer = message_buffer

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -5,9 +5,17 @@ module Datadog
     class SingleThreadSender
       def initialize(message_buffer)
         @message_buffer = message_buffer
+        # store the pid for which this sender has been created
+        update_fork_pid
       end
 
       def add(message)
+        # we have just forked, meaning we have messages in the buffer that we should
+        # not send, they belong to the parent process, let's clear the buffer.
+        if forked?
+          @message_buffer.reset
+          update_fork_pid
+        end
         @message_buffer.add(message)
       end
 
@@ -25,6 +33,17 @@ module Datadog
 
       # Compatibility with `Sender`
       def rendez_vous()
+      end
+
+      # below are "fork management" methods to be able to clean the MessageBuffer
+      # if it detects that it is running in a unknown PID.
+
+      def forked?
+        Process.pid != @fork_pid
+      end
+
+      def update_fork_pid
+        @fork_pid = Process.pid
       end
     end
   end

--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -23,10 +23,15 @@ module Datadog
         connect
       end
 
+      def close
+        @socket.close if @socket
+        @socket = nil
+      end
+
       private
 
       def connect
-        @socket.close if @socket
+        close if @socket
 
         @socket = UDPSocket.new
         @socket.connect(host, port)

--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -26,7 +26,7 @@ module Datadog
       private
 
       def connect
-        @socket.close unless @socket == nil
+        @socket.close if @socket
 
         @socket = UDPSocket.new
         @socket.connect(host, port)

--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -19,18 +19,21 @@ module Datadog
 
         @host = host || ENV.fetch('DD_AGENT_HOST', DEFAULT_HOST)
         @port = port || ENV.fetch('DD_DOGSTATSD_PORT', DEFAULT_PORT).to_i
+        @socket = nil
+        connect
       end
 
       private
 
       def connect
-        UDPSocket.new.tap do |socket|
-          socket.connect(host, port)
-        end
+        @socket.close unless @socket == nil
+
+        @socket = UDPSocket.new
+        @socket.connect(host, port)
       end
 
       def send_message(message)
-        socket.send(message, 0)
+        @socket.send(message, 0)
       end
     end
   end

--- a/lib/datadog/statsd/uds_connection.rb
+++ b/lib/datadog/statsd/uds_connection.rb
@@ -14,20 +14,26 @@ module Datadog
         super(**kwargs)
 
         @socket_path = socket_path
+        @socket = nil
+        connect
+      end
+
+      def close
+        @socket.close if @socket
+        @socket = nil
       end
 
       private
 
       def connect
-        @socket.close unless @socket == nil
+        close unless @socket == nil
 
-        socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
-        socket.connect(Socket.pack_sockaddr_un(@socket_path))
-        socket
+        @socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+        @socket.connect(Socket.pack_sockaddr_un(@socket_path))
       end
 
       def send_message(message)
-        socket.sendmsg_nonblock(message)
+        @socket.sendmsg_nonblock(message)
       rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ENOENT => e
         @socket = nil
         # TODO: FIXME: This error should be considered as a retryable error in the

--- a/lib/datadog/statsd/uds_connection.rb
+++ b/lib/datadog/statsd/uds_connection.rb
@@ -19,6 +19,8 @@ module Datadog
       private
 
       def connect
+        @socket.close unless @socket == nil
+
         socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
         socket.connect(Socket.pack_sockaddr_un(@socket_path))
         socket

--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -105,7 +105,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds the sender' do
         expect(Datadog::Statsd::Sender)
           .to receive(:new)
-          .with(message_buffer)
+          .with(message_buffer, logger: logger)
           .exactly(1)
 
         subject
@@ -283,7 +283,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds the sender' do
         expect(Datadog::Statsd::Sender)
           .to receive(:new)
-          .with(message_buffer)
+          .with(message_buffer, logger: logger)
           .exactly(1)
 
         subject

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -162,6 +162,7 @@ describe Datadog::Statsd do
 
         before do
           allow(Socket).to receive(:new).and_call_original
+          .with(Socket.pack_sockaddr_un('/tmp/socket')) # fake UDS socket
         end
 
         it 'uses an UDS socket' do


### PR DESCRIPTION
We want to reset the `MessageBuffer` if we appear to be in a recent fork, since the contained messages belong to the parent process.

On top of that, when using the original multi-threaded Sender, this PR is re-spawning the companion thread if it seems to be dead for whatever reasons. It should automatically help when someone is using the multi-threaded mode in an app or framework using forks.

For some reasons, I had to remove the use of `UDPSocket.new.tap` since it was causing the interpreter to crash as soon as there was re-creation of a thread in fork childs.

This is a follow-up of and is replacing #199.