### PR TITLE
Update the version test to just check format

### DIFF
--- a/spec/statsd/version_spec.rb
+++ b/spec/statsd/version_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Datadog::Statsd do
   describe 'VERSION' do
     it 'has a version' do
-      expect(Datadog::Statsd::VERSION).to eq '5.3.1'
+      expect(Datadog::Statsd::VERSION).to match /\d+\.\d+\.\d+/
     end
   end
 end


### PR DESCRIPTION
It's good to have a test to make sure VERSION is set, but asserting that
it is equal to a specific version just means we have to change the
version in two places.  This updates the test to just check that it's a
X.Y.Z version.