### PR TITLE
Allow setting socket path with DD_DOGSTATSD_SOCKET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [//]: # (comment: Don't forget to update lib/datadog/statsd/version.rb:DogStatsd::Statsd::VERSION when releasing a new version)
 
+  * [ENHANCEMENT] The client can now be configured to use UDS via the `DD_DOGSTATSD_SOCKET` environment variable.
+    This variable does not take precedence over any explicit parameters passed to the Statsd constructor.
+
 ## 5.3.2 / 2021.11.03
 
   * [OTHER] add a warning message for the v5.x update on install #222 by @djmitche

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -5,6 +5,7 @@ require_relative 'statsd/version'
 require_relative 'statsd/telemetry'
 require_relative 'statsd/udp_connection'
 require_relative 'statsd/uds_connection'
+require_relative 'statsd/connection_cfg'
 require_relative 'statsd/message_buffer'
 require_relative 'statsd/serialization'
 require_relative 'statsd/sender'
@@ -118,9 +119,11 @@ module Datadog
       end
 
       @forwarder = Forwarder.new(
-        host: host,
-        port: port,
-        socket_path: socket_path,
+        connection_cfg: ConnectionCfg.new(
+          host: host,
+          port: port,
+          socket_path: socket_path,
+        ),
 
         global_tags: tags,
         logger: logger,

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -78,11 +78,10 @@ module Datadog
     def initialize(
       host = nil,
       port = nil,
-      socket_path: nil,
+      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
 
       namespace: nil,
       tags: nil,
-      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
       sample_rate: nil,
 
       buffer_max_payload_size: nil,

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -79,7 +79,7 @@ module Datadog
     def initialize(
       host = nil,
       port = nil,
-      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
+      socket_path: nil,
 
       namespace: nil,
       tags: nil,

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -82,6 +82,7 @@ module Datadog
 
       namespace: nil,
       tags: nil,
+      socket_path: ENV['DD_DOGSTATSD_SOCKET'],
       sample_rate: nil,
 
       buffer_max_payload_size: nil,

--- a/lib/datadog/statsd/connection_cfg.rb
+++ b/lib/datadog/statsd/connection_cfg.rb
@@ -1,0 +1,64 @@
+module Datadog
+  class Statsd
+    class ConnectionCfg
+      attr_reader :host
+      attr_reader :port
+      attr_reader :socket_path
+      attr_reader :transport_type
+
+      DEFAULT_HOST = '127.0.0.1'
+      DEFAULT_PORT = 8125
+
+      def initialize(host: nil, port: nil, socket_path: nil)
+
+        # Try with constructor args
+        if setup_with(host, port, socket_path)
+          return
+        end
+
+        # Try with env vars
+        if setup_with(
+            ENV['DD_AGENT_HOST'],
+            ENV['DD_DOGSTATSD_PORT'].nil? ? nil : ENV['DD_DOGSTATSD_PORT'].to_i,
+            ENV['DD_DOGSTATSD_SOCKET'])
+          return
+        end
+
+        # Fall back to defaults
+        setup_with(DEFAULT_HOST, DEFAULT_PORT, nil)
+      end
+
+      # set up the configuration with the given values; this is a helper for #initialize
+      def setup_with(host, port, socket_path)
+        if (host || port) && socket_path
+          raise ArgumentError, "Do not set both host/port and socket_path"
+        end
+
+        if host || port 
+          @host = host || DEFAULT_HOST
+          @port = port || DEFAULT_PORT
+          @socket_path = nil
+          @transport_type = :udp
+          return true
+        elsif socket_path
+          @host = nil
+          @port = nil
+          @socket_path = socket_path
+          @transport_type = :uds
+          return true
+        end
+
+        return false
+      end
+
+      def make_connection(**params)
+        case @transport_type
+        when :udp
+          UDPConnection.new(@host, @port, **params)
+        when :uds
+          UDSConnection.new(@socket_path, **params)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/statsd/connection_cfg.rb
+++ b/lib/datadog/statsd/connection_cfg.rb
@@ -29,8 +29,8 @@ module Datadog
       def initialize_with_constructor_args(host: nil, port: nil, socket_path: nil)
         try_initialize_with(host: host, port: port, socket_path: socket_path,
           not_both_error_message: 
-            "Both UDP: (host/port %s:%s) and UDS (socket_path %s) constructor arguments were given.  Use only one or the other." %
-            [host, port, socket_path],
+            "Both UDP: (host/port #{host}:#{port}) and UDS (socket_path #{socket_path}) " +
+            "constructor arguments were given. Use only one or the other.",
           )
       end
 
@@ -40,7 +40,9 @@ module Datadog
           port: ENV['DD_DOGSTATSD_PORT'] && ENV['DD_DOGSTATSD_PORT'].to_i,
           socket_path: ENV['DD_DOGSTATSD_SOCKET'],
           not_both_error_message:
-            "Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT %s:%s) and UDS (DD_DOGSTATSD_SOCKET %s) environment variables are set.  Set only one or the other." %
+            "Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT #{ENV['DD_AGENT_HOST']}:#{ENV['DD_DOGSTATSD_PORT']}) " +
+            "and UDS (DD_DOGSTATSD_SOCKET #{ENV['DD_DOGSTATSD_SOCKET']}) environment variables are set. " +
+            "Set only one or the other." %
             [ENV['DD_AGENT_HOST'], ENV['DD_DOGSTATSD_PORT'], ENV['DD_DOGSTATSD_SOCKET']])
       end
 

--- a/lib/datadog/statsd/connection_cfg.rb
+++ b/lib/datadog/statsd/connection_cfg.rb
@@ -26,7 +26,7 @@ module Datadog
       DEFAULT_HOST = '127.0.0.1'
       DEFAULT_PORT = 8125
 
-      def initialize_with_constructor_args(host:, port:, socket_path:)
+      def initialize_with_constructor_args(host: nil, port: nil, socket_path: nil)
         try_initialize_with(host: host, port: port, socket_path: socket_path,
           not_both_error_message: 
             "Both UDP: (host/port %s:%s) and UDS (socket_path %s) constructor arguments were given.  Use only one or the other." %
@@ -48,7 +48,7 @@ module Datadog
         try_initialize_with(host: DEFAULT_HOST, port: DEFAULT_PORT)
       end
 
-      def try_initialize_with(host:, port:, socket_path: nil, not_both_error_message: "")
+      def try_initialize_with(host: nil, port: nil, socket_path: nil, not_both_error_message: "")
         if (host || port) && socket_path
           raise ArgumentError, not_both_error_message
         end

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -7,7 +7,7 @@ module Datadog
       attr_reader :transport_type
 
       def initialize(
-        connection_cfg: nil,
+        connection_cfg:,
 
         buffer_max_payload_size: nil,
         buffer_max_pool_size: nil,

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -7,7 +7,7 @@ module Datadog
       attr_reader :transport_type
 
       def initialize(
-        connection_cfg:,
+        connection_cfg: nil,
 
         buffer_max_payload_size: nil,
         buffer_max_pool_size: nil,

--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -5,20 +5,17 @@ require_relative 'connection'
 module Datadog
   class Statsd
     class UDPConnection < Connection
-      DEFAULT_HOST = '127.0.0.1'
-      DEFAULT_PORT = 8125
-
-      # StatsD host. Defaults to 127.0.0.1.
+      # StatsD host.
       attr_reader :host
 
-      # StatsD port. Defaults to 8125.
+      # StatsD port.
       attr_reader :port
 
       def initialize(host, port, **kwargs)
         super(**kwargs)
 
-        @host = host || ENV.fetch('DD_AGENT_HOST', DEFAULT_HOST)
-        @port = port || ENV.fetch('DD_DOGSTATSD_PORT', DEFAULT_PORT).to_i
+        @host = host
+        @port = port
         @socket = nil
       end
 

--- a/spec/statsd/connection_cfg_spec.rb
+++ b/spec/statsd/connection_cfg_spec.rb
@@ -57,7 +57,7 @@ describe Datadog::Statsd::ConnectionCfg do
           subject.new(host: host, port: port, socket_path: socket_path)
         end.to raise_error(
           ArgumentError,
-          "Both UDP: (host/port my-agent:1234) and UDS (socket_path /some/socket) constructor arguments were given.  Use only one or the other.")
+          "Both UDP: (host/port my-agent:1234) and UDS (socket_path /some/socket) constructor arguments were given. Use only one or the other.")
       end
     end
 
@@ -153,7 +153,7 @@ describe Datadog::Statsd::ConnectionCfg do
           subject.new(host: host, port: port, socket_path: socket_path)
         end.to raise_error(
           ArgumentError,
-          'Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT some-host:) and UDS (DD_DOGSTATSD_SOCKET /some/socket) environment variables are set.  Set only one or the other.')
+          'Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT some-host:) and UDS (DD_DOGSTATSD_SOCKET /some/socket) environment variables are set. Set only one or the other.')
       end
     end
 

--- a/spec/statsd/connection_cfg_spec.rb
+++ b/spec/statsd/connection_cfg_spec.rb
@@ -55,7 +55,9 @@ describe Datadog::Statsd::ConnectionCfg do
       it 'raises an exception' do
         expect do
           subject.new(host: host, port: port, socket_path: socket_path)
-        end.to raise_error(ArgumentError, 'Do not set both host/port and socket_path')
+        end.to raise_error(
+          ArgumentError,
+          'Both host/port and socket_path constructor arguments are set.  Set only one or the other.')
       end
     end
 
@@ -149,7 +151,9 @@ describe Datadog::Statsd::ConnectionCfg do
       it 'raises an exception' do
         expect do
           subject.new(host: host, port: port, socket_path: socket_path)
-        end.to raise_error(ArgumentError, 'Do not set both host/port and socket_path')
+        end.to raise_error(
+          ArgumentError,
+          'Both $DD_AGENT_HOST/$DD_DOGSTATSD_PORT and $DD_DOGSTATSD_SOCKET are set.  Set only one or the other.')
       end
     end
 
@@ -184,10 +188,7 @@ describe Datadog::Statsd::ConnectionCfg do
       let(:host) { 'my-agent' }
       let(:port) { 1234 }
       let(:udp_connection) do
-        instance_double(Datadog::Statsd::UDPConnection,
-          host: host,
-          port: port
-        )
+        instance_double(Datadog::Statsd::UDPConnection)
       end
 
       it 'creates a UDP connection, passing along params' do

--- a/spec/statsd/connection_cfg_spec.rb
+++ b/spec/statsd/connection_cfg_spec.rb
@@ -57,7 +57,7 @@ describe Datadog::Statsd::ConnectionCfg do
           subject.new(host: host, port: port, socket_path: socket_path)
         end.to raise_error(
           ArgumentError,
-          'Both host/port and socket_path constructor arguments are set.  Set only one or the other.')
+          "Both UDP: (host/port my-agent:1234) and UDS (socket_path /some/socket) constructor arguments were given.  Use only one or the other.")
       end
     end
 
@@ -153,7 +153,7 @@ describe Datadog::Statsd::ConnectionCfg do
           subject.new(host: host, port: port, socket_path: socket_path)
         end.to raise_error(
           ArgumentError,
-          'Both $DD_AGENT_HOST/$DD_DOGSTATSD_PORT and $DD_DOGSTATSD_SOCKET are set.  Set only one or the other.')
+          'Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT some-host:) and UDS (DD_DOGSTATSD_SOCKET /some/socket) environment variables are set.  Set only one or the other.')
       end
     end
 

--- a/spec/statsd/connection_cfg_spec.rb
+++ b/spec/statsd/connection_cfg_spec.rb
@@ -1,0 +1,218 @@
+require 'spec_helper'
+
+describe Datadog::Statsd::ConnectionCfg do
+  subject do
+    described_class.new(host: host, port: port, socket_path: socket_path)
+  end
+
+  around do |example|
+    ClimateControl.modify(
+      'DD_AGENT_HOST' => dd_agent_host,
+      'DD_DOGSTATSD_PORT' => dd_dogstatsd_port,
+      'DD_DOGSTATSD_SOCKET' => dd_dogstatsd_socket,
+    ) do
+      example.run
+    end
+  end
+
+  let(:host) { nil }
+  let(:port) { nil }
+  let(:socket_path) { nil }
+  let(:dd_agent_host) { nil }
+  let(:dd_dogstatsd_port) { nil }
+  let(:dd_dogstatsd_socket) { nil }
+
+  describe '#initialize' do
+    context 'with host/port args and env vars set' do
+      let(:host) { 'my-agent' }
+      let(:port) { 1234 }
+      let(:dd_agent_host) { 'unused' }
+      let(:dd_dogstatsd_port) { '999' }
+      let(:dd_dogstatsd_socket) { '/un/used' }
+
+      it 'creates a UDP connection' do
+        expect(subject.transport_type).to eq :udp
+      end
+
+      it 'uses the agent name from the args' do
+        expect(subject.host).to eq 'my-agent'
+      end
+
+      it 'uses the port name from the args' do
+        expect(subject.port).to eq 1234
+      end
+
+      it 'sets socket_path to nil' do
+        expect(subject.socket_path).to eq nil
+      end
+    end
+
+    context 'with both host/port and socket args' do
+      let(:host) { 'my-agent' }
+      let(:port) { 1234 }
+      let(:socket_path) { '/some/socket' }
+
+      it 'raises an exception' do
+        expect do
+          subject.new(host: host, port: port, socket_path: socket_path)
+        end.to raise_error(ArgumentError, 'Do not set both host/port and socket_path')
+      end
+    end
+
+    context 'with socket_path arg and env vars' do
+      let(:socket_path) { '/some/socket' }
+      let(:dd_agent_host) { 'unused' }
+      let(:dd_dogstatsd_port) { '999' }
+      let(:dd_dogstatsd_socket) { '/un/used' }
+
+      it 'creates a UDS connection' do
+        expect(subject.transport_type).to eq :uds
+      end
+
+      it 'sets host to nil' do
+        expect(subject.host).to eq nil
+      end
+
+      it 'sets port to nil' do
+        expect(subject.port).to eq nil
+      end
+
+      it 'sets socket_path to path in the arg' do
+        expect(subject.socket_path).to eq '/some/socket'
+      end
+    end
+
+    context 'with no args and DD_AGENT_HOST set' do
+      let(:dd_agent_host) { 'some-host' }
+
+      it 'creates a UDP connection' do
+        expect(subject.transport_type).to eq :udp
+      end
+
+      it 'sets host to DD_AGENT_HOST' do
+        expect(subject.host).to eq 'some-host'
+      end
+
+      it 'sets port to 8125 (default)' do
+        expect(subject.port).to eq 8125
+      end
+
+      it 'sets socket_path to nil' do
+        expect(subject.socket_path).to eq nil
+      end
+
+      context 'and DD_DOGSTATSD_PORT set' do
+        let(:dd_dogstatsd_port) { '1234' }
+
+        it 'creates a UDP connection' do
+          expect(subject.transport_type).to eq :udp
+        end
+
+        it 'sets host to DD_AGENT_HOST' do
+          expect(subject.host).to eq 'some-host'
+        end
+
+        it 'sets port to DD_DOGSTATSD_PORT' do
+          expect(subject.port).to eq 1234
+        end
+
+        it 'sets socket_path to nil' do
+          expect(subject.socket_path).to eq nil
+        end
+      end
+    end
+
+    context 'with no args and DD_DOGSTATSD_SOCKET set' do
+      let(:dd_dogstatsd_socket) { '/some/socket' }
+
+      it 'creates a UDS connection' do
+        expect(subject.transport_type).to eq :uds
+      end
+
+      it 'sets host to nil' do
+        expect(subject.host).to eq nil
+      end
+
+      it 'sets port to nil' do
+        expect(subject.port).to eq nil
+      end
+
+      it 'sets socket_path to DD_DOGSTATSD_SOCKET' do
+        expect(subject.socket_path).to eq '/some/socket'
+      end
+    end
+
+    context 'with both DD_AGENT_HOST and DD_DOGSTATSD_SOCKET set' do
+      let(:dd_agent_host) { 'some-host' }
+      let(:dd_dogstatsd_socket) { '/some/socket' }
+
+      it 'raises an exception' do
+        expect do
+          subject.new(host: host, port: port, socket_path: socket_path)
+        end.to raise_error(ArgumentError, 'Do not set both host/port and socket_path')
+      end
+    end
+
+    context 'with no args and no env vars set' do
+      it 'creates a UDP connection' do
+        expect(subject.transport_type).to eq :udp
+      end
+
+      it 'sets host to 127.0.0.1 (default)' do
+        expect(subject.host).to eq '127.0.0.1'
+      end
+
+      it 'sets port to 8125 (default)' do
+        expect(subject.port).to eq 8125
+      end
+
+      it 'sets socket_path to nil' do
+        expect(subject.socket_path).to eq nil
+      end
+    end
+  end
+
+  describe '#make_connection' do
+    context 'for a UDP connection' do
+      before do
+        allow(Datadog::Statsd::UDPConnection)
+          .to receive(:new)
+          .with(host, port, param: 'param')
+          .and_return(udp_connection)
+      end
+
+      let(:host) { 'my-agent' }
+      let(:port) { 1234 }
+      let(:udp_connection) do
+        instance_double(Datadog::Statsd::UDPConnection,
+          host: host,
+          port: port
+        )
+      end
+
+      it 'creates a UDP connection, passing along params' do
+        expect(subject.make_connection(param: 'param')).to eq udp_connection
+      end
+    end
+
+    context 'for a UDS connection' do
+      before do
+        allow(Datadog::Statsd::UDSConnection)
+          .to receive(:new)
+          .with(socket_path, param: 'param')
+          .and_return(uds_connection)
+      end
+
+      let(:socket_path) { '/tmp/dd-socket' }
+      let(:uds_connection) do
+        instance_double(Datadog::Statsd::UDSConnection,
+          socket_path: socket_path
+        )
+      end
+
+      it 'creates a UDS connection, passing along params' do
+        expect(subject.make_connection(param: 'param')).to eq uds_connection
+      end
+    end
+  end
+end

--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -79,8 +79,7 @@ describe Datadog::Statsd::Forwarder do
 
     let(:params) do
       {
-        host: host,
-        port: port,
+        connection_cfg: Datadog::Statsd::ConnectionCfg.new(host: host, port: port),
 
         buffer_max_payload_size: buffer_max_payload_size,
         buffer_max_pool_size: buffer_max_pool_size,
@@ -258,7 +257,7 @@ describe Datadog::Statsd::Forwarder do
 
     let(:params) do
       {
-        socket_path: socket_path,
+        connection_cfg: Datadog::Statsd::ConnectionCfg.new(socket_path: socket_path),
 
         buffer_max_payload_size: buffer_max_payload_size,
         buffer_max_pool_size: buffer_max_pool_size,
@@ -391,9 +390,9 @@ describe Datadog::Statsd::Forwarder do
     end
 
     its(:transport_type) { is_expected.to eq :uds }
-    its(:host) { is_expected.to be_nil }
-    its(:port) { is_expected.to be_nil }
-    its(:socket_path) { is_expected.to eq '/tmp/dd_socket' }
+    its(:host) { is_expected.to eq nil }
+    its(:port) { is_expected.to eq nil }
+    its(:socket_path) { is_expected.to eq '/tmp/dd_socket'  }
 
     describe '#close' do
       before do
@@ -441,8 +440,7 @@ describe Datadog::Statsd::Forwarder do
 
     let(:params) do
       {
-        host: host,
-        port: port,
+        connection_cfg: Datadog::Statsd::ConnectionCfg.new(host: host, port: port),
 
         buffer_max_payload_size: buffer_max_payload_size,
         buffer_max_pool_size: buffer_max_pool_size,

--- a/spec/statsd/udp_connection_spec.rb
+++ b/spec/statsd/udp_connection_spec.rb
@@ -47,50 +47,6 @@ describe Datadog::Statsd::UDPConnection do
       expect(UDPSocket).to_not receive(:new)
       subject
     end
-
-    context 'when no host is provided' do
-      let(:host) do
-        nil
-      end
-
-      it 'uses the default host' do
-        expect(subject.host).to eq Datadog::Statsd::UDPConnection::DEFAULT_HOST
-      end
-
-      context 'when DD_AGENT_HOST env var is provided' do
-        around do |example|
-          ClimateControl.modify('DD_AGENT_HOST' => 'myhost') do
-            example.run
-          end
-        end
-
-        it 'uses the environment variable DD_AGENT_HOST to set the host' do
-          expect(subject.host).to eq 'myhost'
-        end
-      end
-    end
-
-    context 'when no port is provided' do
-      let(:port) do
-        nil
-      end
-
-      it 'uses the default port' do
-        expect(subject.port).to eq Datadog::Statsd::UDPConnection::DEFAULT_PORT
-      end
-
-      context 'when DD_DOGSTATSD_PORT env var is provided' do
-        around do |example|
-          ClimateControl.modify('DD_DOGSTATSD_PORT' => '1337') do
-            example.run
-          end
-        end
-
-        it 'uses the environment variable DD_DOGSTATSD_PORT to set the port' do
-          expect(subject.port).to eq 1337
-        end
-      end
-    end
   end
 
   describe '#write' do

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -104,6 +104,20 @@ describe Datadog::Statsd do
           'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
         ]
       end
+
+      context 'when the socket environment variable is set' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_DOGSTATSD_SOCKET' => '/some/socket',
+          ) do
+            example.run
+          end
+        end
+
+        it 'sets the socket to the environment variables value' do
+          expect(subject.connection.socket_path).to eq '/some/socket'
+        end
+      end
     end
 
     context 'when using default values' do

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -104,20 +104,6 @@ describe Datadog::Statsd do
           'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
         ]
       end
-
-      context 'when the socket environment variable is set' do
-        around do |example|
-          ClimateControl.modify(
-            'DD_DOGSTATSD_SOCKET' => '/some/socket',
-          ) do
-            example.run
-          end
-        end
-
-        it 'sets the socket to the environment variables value' do
-          expect(subject.connection.socket_path).to eq '/some/socket'
-        end
-      end
     end
 
     context 'when using default values' do


### PR DESCRIPTION
This is an extension of #163, adding an explicit preference for constructor arguments over environment variables.

This is just cleaner, but in particular this addresses the case where a user might currently be passing constructor args (`Statsd.new(someHost, somePort)`) and would find it surprising if suddenly an already-existing 
$DD_DOGSTATSD_SOCKET took precedence over those.