### PR TITLE
specs: fix some tests after recent merge in `master`

### DIFF
--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -109,7 +109,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds the sender' do
         expect(Datadog::Statsd::Sender)
           .to receive(:new)
-          .with(message_buffer, logger: logger, flush_interval: flush_interval)
+          .with(message_buffer, logger: logger, flush_interval: buffer_flush_interval)
           .exactly(1)
 
         subject
@@ -288,7 +288,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds the sender' do
         expect(Datadog::Statsd::Sender)
           .to receive(:new)
-          .with(message_buffer, logger: logger, flush_interval: flush_interval)
+          .with(message_buffer, logger: logger, flush_interval: buffer_flush_interval)
           .exactly(1)
 
         subject

--- a/spec/statsd/single_thread_sender_spec.rb
+++ b/spec/statsd/single_thread_sender_spec.rb
@@ -62,6 +62,7 @@ describe Datadog::Statsd::SingleThreadSender do
       let(:flush_interval) { 15 }
 
       it 'stops the flush timer thread' do
+        allow(subject).to receive(:flush)
         expect do
           subject.stop
         end.to change { Thread.list.size }.by(-1)

--- a/spec/statsd/timer_spec.rb
+++ b/spec/statsd/timer_spec.rb
@@ -62,7 +62,7 @@ describe Datadog::Statsd::Timer do
     before do
       subject.start
       # sleep a little for the thread to call ConditionVariable#wait
-      sleep 0.000001
+      sleep 0.01
     end
 
     it 'stops the timer thread after calling the callback' do


### PR DESCRIPTION
A few unit tests are failing since the merge of #231:

* a couple typos,
* one of the spec test is sometimes failing because the timer is triggered and is triggering a `:flush`, but not always. so I'm allowing the `:flush` to happen.
* one of the spec test is relying on a sleep, which is not ideal (already mentioned in the PR) and was failing on my laptop.