### PR TITLE
Add a `pre_sampled` option to metric methods

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -151,6 +151,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @option opts [Numeric] :by increment value, default 1
     # @see #count
@@ -165,6 +166,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @option opts [Numeric] :by decrement value, default 1
     # @see #count
@@ -180,6 +182,7 @@ module Datadog
     # @param [Integer] count count
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     def count(stat, count, opts = EMPTY_OPTIONS)
       opts = { sample_rate: opts } if opts.is_a?(Numeric)
@@ -196,6 +199,7 @@ module Datadog
     # @param [Numeric] value gauge value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.gauge('user.count', User.count)
@@ -210,6 +214,7 @@ module Datadog
     # @param [Numeric] value histogram value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.histogram('user.count', User.count)
@@ -223,6 +228,7 @@ module Datadog
     # @param [Numeric] value distribution value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @example Report the current user count:
     #   $statsd.distribution('user.count', User.count)
@@ -239,6 +245,7 @@ module Datadog
     # @param [Integer] ms timing in milliseconds
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     def timing(stat, ms, opts = EMPTY_OPTIONS)
       opts = { sample_rate: opts } if opts.is_a?(Numeric)
@@ -253,6 +260,7 @@ module Datadog
     # @param [String] stat stat name
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @yield The operation to be timed
     # @see #timing
@@ -272,6 +280,7 @@ module Datadog
     # @param [Numeric] value set value.
     # @param [Hash] opts the options to create the metric with
     # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Boolean] :pre_sampled If true, the client assumes the caller has already sampled metrics at :sample_rate, and doesn't perform sampling.
     # @option opts [Array<String>] :tags An array of tags
     # @example Record a unique visitory by id:
     #   $statsd.set('visitors.uniques', User.id)
@@ -394,7 +403,7 @@ module Datadog
 
       sample_rate = opts[:sample_rate] || @sample_rate || 1
 
-      if sample_rate == 1 || rand <= sample_rate
+      if sample_rate == 1 || opts[:pre_sampled] || rand <= sample_rate
         full_stat = serializer.to_stat(stat, delta, type, tags: opts[:tags], sample_rate: sample_rate)
 
         forwarder.send_message(full_stat)

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -271,6 +271,19 @@ describe Datadog::Statsd do
       end
     end
 
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.increment('foobar', sample_rate: 0.5, pre_sampled: true)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'foobar:1|c|@0.5'
+      end
+    end
+
     context 'with a increment by' do
       it 'increments by the number given' do
         subject.increment('foobar', by: 5)
@@ -326,6 +339,19 @@ describe Datadog::Statsd do
       end
     end
 
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.decrement('foobar', sample_rate: 0.5, pre_sampled: true)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'foobar:-1|c|@0.5'
+      end
+    end
+
     context 'with a decrement by' do
       it 'decrements by the number given' do
         subject.decrement('foobar', by: 5)
@@ -362,6 +388,19 @@ describe Datadog::Statsd do
 
       it 'sends the count with sample rate' do
         subject.count('foobar', 123, 0.1)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'foobar:123|c|@0.1'
+      end
+    end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.count('foobar', 123, sample_rate: 0.1, pre_sampled: true)
         subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:123|c|@0.1'
@@ -425,6 +464,19 @@ describe Datadog::Statsd do
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
       end
     end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.gauge('begrutten-suffusion', 536, sample_rate: 0.1, pre_sampled: true)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
+      end
+    end
   end
 
   describe '#histogram' do
@@ -468,6 +520,19 @@ describe Datadog::Statsd do
         subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
+      end
+    end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.histogram('ohmy', 536, sample_rate: 0.1, pre_sampled: true)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'ohmy:536|h|@0.1'
       end
     end
   end
@@ -516,6 +581,19 @@ describe Datadog::Statsd do
         expect(socket.recv[0]).to eq_with_telemetry 'my.set:536|s|@0.5'
       end
     end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.set('my.set', 536, sample_rate: 0.5, pre_sampled: true)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'my.set:536|s|@0.5'
+      end
+    end
   end
 
   describe '#timing' do
@@ -557,6 +635,19 @@ describe Datadog::Statsd do
 
       it 'sends the timing with the sample rate' do
         subject.timing('foobar', 500, 0.5)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'foobar:500|ms|@0.5'
+      end
+    end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.timing('foobar', 500, sample_rate: 0.5, pre_sampled: true)
         subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:500|ms|@0.5'
@@ -673,6 +764,23 @@ describe Datadog::Statsd do
         expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
       end
     end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.time('foobar', sample_rate: 0.5, pre_sampled: true) do
+          Timecop.travel(after_date)
+          allow(Process).to receive(:clock_gettime).and_return(1)
+        end
+
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'foobar:1000|ms|@0.5'
+      end
+    end
   end
 
   describe '#distribution' do
@@ -701,6 +809,19 @@ describe Datadog::Statsd do
 
       it 'sends the set with the sample rate' do
         subject.distribution('begrutten-suffusion', 536, sample_rate: 0.5)
+        subject.flush(sync: true)
+
+        expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|d|@0.5'
+      end
+    end
+
+    context 'with pre sampling' do
+      before do
+        allow(subject).to receive(:rand).and_return(1)
+      end
+
+      it 'sends the sample rate without additional sampling' do
+        subject.distribution('begrutten-suffusion', 536, sample_rate: 0.5, pre_sampled: true)
         subject.flush(sync: true)
 
         expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|d|@0.5'


### PR DESCRIPTION
This should accomplish what #124 is trying to do but this is updated with the latest feedback from that PR and working against the latest changes in 5.x.

My use case is a little bit different from what was discussed in #124. I have a library that can return its own metrics after it's done processing. From the metrics the library returns I then create metrics in dogstatsd-ruby. I'd like to sample the metrics but currently sampling can only be done per metric. This change allows me to control the sample rate of the library and not worry about dogstatsd-ruby additionally sampling the metrics.

There are two additional commits in this PR, while adding tests I noticed a histogram test was actually testing a gauge, so I fixed that. There was a small typo in one of the method documentation comments that I also fixed.