### PR TITLE
Fix histogram test and a typo in statsd.rb

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -186,7 +186,7 @@ module Datadog
       send_stats(stat, count, COUNTER_TYPE, opts)
     end
 
-    # Sends an arbitary gauge value for the given stat to the statsd server.
+    # Sends an arbitrary gauge value for the given stat to the statsd server.
     #
     # This is useful for recording things like available disk space,
     # memory usage, and the like, which have different semantics than

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -464,10 +464,10 @@ describe Datadog::Statsd do
       end
 
       it 'sends the histogram with the sample rate' do
-        subject.gauge('begrutten-suffusion', 536, sample_rate: 0.1)
+        subject.histogram('ohmy', 536, sample_rate: 0.1)
         subject.flush(sync: true)
 
-        expect(socket.recv[0]).to eq_with_telemetry 'begrutten-suffusion:536|g|@0.1'
+        expect(socket.recv[0]).to eq_with_telemetry 'ohmy:536|h|@0.1'
       end
     end
   end


### PR DESCRIPTION
While adding tests in #235 I came across a histogram test that was incorrectly testing a gauge. I've fixed the test to now test a gauge and match the same metric name as the other histogram tests.

Additionally I came across a typo in stated.rb that I fixed.