### PR TITLE
Remove unused string formatting that was causing warnings + display warnings during test suite execution

### DIFF
--- a/lib/datadog/statsd/connection_cfg.rb
+++ b/lib/datadog/statsd/connection_cfg.rb
@@ -42,8 +42,8 @@ module Datadog
           not_both_error_message:
             "Both UDP (DD_AGENT_HOST/DD_DOGSTATSD_PORT #{ENV['DD_AGENT_HOST']}:#{ENV['DD_DOGSTATSD_PORT']}) " +
             "and UDS (DD_DOGSTATSD_SOCKET #{ENV['DD_DOGSTATSD_SOCKET']}) environment variables are set. " +
-            "Set only one or the other." %
-            [ENV['DD_AGENT_HOST'], ENV['DD_DOGSTATSD_PORT'], ENV['DD_DOGSTATSD_SOCKET']])
+            "Set only one or the other.",
+        )
       end
 
       def initialize_with_defaults()

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,4 +32,6 @@ RSpec.configure do |config|
   end
 
   config.expose_dsl_globally = true
+
+  config.warnings = true
 end


### PR DESCRIPTION
Title says it all!

Fixes #234