### PR TITLE
do not close instance if it could not be created

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -143,7 +143,7 @@ module Datadog
 
       yield instance
     ensure
-      instance.close
+      instance&.close
     end
 
     # Sends an increment (count = 1) for the given stat to the statsd server.

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -214,7 +214,6 @@ describe Datadog::Statsd do
       described_class.open {}
     end
 
-
     it 'ensures the statsd instance is closed' do
       expect(fake_statsd).to receive(:close)
 
@@ -223,6 +222,12 @@ describe Datadog::Statsd do
         raise 'stop'
       end rescue nil
       # rubocop:enable Lint/RescueWithoutErrorClass
+    end
+
+    it 'does not hide creation errors' do
+      expect do
+        described_class.open(1,2,3,4,5) {}
+      end.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
turns this:
```
NoMethodError: undefined method `close' for nil:NilClass

      instance.close
              ^^^^^^
    vendor/bundle/ruby/3.1.0/gems/dogstatsd-ruby-5.3.2/lib/datadog/statsd.rb:145:in `ensure in open'
```

into:
```
ArgumentError: wrong number of arguments (given 3, expected 0..2)
    vendor/bundle/ruby/3.1.0/gems/dogstatsd-ruby-5.3.2/lib/datadog/statsd.rb:78:in `initialize'
```