### PR TITLE
do not blow up when using kwargs for .open

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -138,8 +138,9 @@ module Datadog
 
     # yield a new instance to a block and close it when done
     # for short-term use-cases that don't want to close the socket manually
-    def self.open(*args)
-      instance = new(*args)
+    # TODO: replace with ... once we are on ruby 2.7
+    def self.open(*args, **kwargs)
+      instance = new(*args, **kwargs)
 
       yield instance
     ensure

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -229,10 +229,18 @@ describe Datadog::Statsd do
         described_class.open(1,2,3,4,5) {}
       end.to raise_error(ArgumentError)
     end
+  end
 
-    # TODO: this test does not work since .new is stubbed
-    it 'can pass kwargs' do
-      described_class.open(1, 2, namespace: "foo") { }
+  describe '#open with keyword arguments' do
+    before do
+      # avoid initializing Forwarder, but call the real Statsd#new
+      allow(Datadog::Statsd::Forwarder)
+        .to receive(:new)
+        .and_return(instance_double(Datadog::Statsd::Forwarder, flush: true, close: true))
+    end
+
+    it 'forwards the namespace keywor argument correctly' do
+      expect(described_class.open("host", namespace: "ns") { |statsd| statsd.namespace }).to eq 'ns'
     end
   end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -229,6 +229,11 @@ describe Datadog::Statsd do
         described_class.open(1,2,3,4,5) {}
       end.to raise_error(ArgumentError)
     end
+
+    # TODO: this test does not work since .new is stubbed
+    it 'can pass kwargs' do
+      described_class.open(1, 2, namespace: "foo") { }
+    end
   end
 
   describe '#increment' do


### PR DESCRIPTION
```
ArgumentError: wrong number of arguments (given 3, expected 0..2)
    vendor/bundle/ruby/3.1.0/gems/dogstatsd-ruby-5.3.2/lib/datadog/statsd.rb:78:in `initialize'
```