### PR TITLE
Plan to drop support through Ruby-2.4 in next minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ As much as possible, we will add a "future deprecation" message in the minor rel
 
 This gem supports and is tested on Ruby minor versions 2.1 through 3.0.
 Support for Ruby 2.0 was dropped in version 5.4.0.
+Support for Ruby 2.1 through 2.4 will be dropped in version 5.5.0.
 
 ## Credits
 


### PR DESCRIPTION
Ruby-2.4 [has been EOL for almost two years](https://www.ruby-lang.org/en/downloads/branches/).
