### PR TITLE
Add a "distribution_time" method

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -250,6 +250,7 @@ module Datadog
     # @example Report the time (in ms) taken to activate an account
     #   $statsd.distribution_time('account.activate') { @account.activate! }
     def distribution_time(stat, opts = EMPTY_OPTIONS)
+      opts = { sample_rate: opts } if opts.is_a?(Numeric)
       start = now
       yield
     ensure

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -237,6 +237,25 @@ module Datadog
       send_stats(stat, value, DISTRIBUTION_TYPE, opts)
     end
 
+    # Reports execution time of the provided block as a distribution.
+    #
+    # If the block fails, the stat is still reported, then the error
+    # is reraised
+    #
+    # @param [String] stat stat name.
+    # @param [Numeric] value distribution value.
+    # @param [Hash] opts the options to create the metric with
+    # @option opts [Numeric] :sample_rate sample rate, 1 for always
+    # @option opts [Array<String>] :tags An array of tags
+    # @example Report the time (in ms) taken to activate an account
+    #   $statsd.distribution_time('account.activate') { @account.activate! }
+    def distribution_time(stat, opts = EMPTY_OPTIONS)
+      start = now
+      yield
+    ensure
+      distribution(stat, ((now - start) * 1000).round, opts)
+    end
+
     # Sends a timing (in ms) for the given stat to the statsd server. The
     # sample_rate determines what percentage of the time this report is sent. The
     # statsd server then uses the sample_rate to correctly track the average


### PR DESCRIPTION
Note: New PR for #200 with tests added.

--------

Add a "distribution_time" method to facilitate measuring timing for
a yielded block and report it as a distribution metric instead of as a
histogram metric.