### PR TITLE
Stop flush timer before closing queue

### DIFF
--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -102,10 +102,11 @@ module Datadog
         # to close the sender nor trying to continue to `#add` more message
         # into the sender.
         def stop(join_worker: true)
+          @flush_timer.stop if @flush_timer
+
           message_queue = @message_queue
           message_queue.close if message_queue
 
-          @flush_timer.stop if @flush_timer
           sender_thread = @sender_thread
           sender_thread.join if sender_thread && join_worker
         end
@@ -114,10 +115,11 @@ module Datadog
         # to close the sender nor trying to continue to `#add` more message
         # into the sender.
         def stop(join_worker: true)
+          @flush_timer.stop if @flush_timer
+
           message_queue = @message_queue
           message_queue << :close if message_queue
 
-          @flush_timer.stop if @flush_timer
           sender_thread = @sender_thread
           sender_thread.join if sender_thread && join_worker
         end

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -111,6 +111,10 @@ describe Datadog::Statsd::Sender do
       let(:flush_interval) { 15 }
 
       it 'stops the worker thread and the flush timer thread' do
+        # sleep a little to wait for the sender thread to start
+        sleep 0.01
+
+        expect(message_buffer).to receive(:flush)
         expect do
           subject.stop
         end.to change { Thread.list.size }.by(-2)


### PR DESCRIPTION
As `Datadog::Sender#flush` adds `:flush` command to the queue, the flush timer should be closed before the sender closes the queue to avoid ClosedQueueError.
