### PR TITLE
Resolve warnings

### DIFF
--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -25,11 +25,13 @@ module Datadog
       )
         @transport_type = connection_cfg.transport_type
 
-        if telemetry_flush_interval
-          @telemetry = Telemetry.new(telemetry_flush_interval,
+        @telemetry = if telemetry_flush_interval
+          Telemetry.new(telemetry_flush_interval,
             global_tags: global_tags,
             transport_type: @transport_type
           )
+        else
+          nil
         end
 
         @connection = connection_cfg.make_connection(logger: logger, telemetry: telemetry)

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -20,8 +20,10 @@ module Datadog
         @mx = Mutex.new
         @queue_class = queue_class
         @thread_class = thread_class
-        if flush_interval
-          @flush_timer = Datadog::Statsd::Timer.new(flush_interval) { flush(sync: true) }
+        @flush_timer = if flush_interval
+          Datadog::Statsd::Timer.new(flush_interval) { flush(sync: true) }
+        else
+          nil
         end
       end
 

--- a/lib/datadog/statsd/timer.rb
+++ b/lib/datadog/statsd/timer.rb
@@ -9,6 +9,7 @@ module Datadog
         @interval = interval
         @callback = callback
         @stop = true
+        @thread = nil
       end
 
       def start

--- a/spec/statsd/version_spec.rb
+++ b/spec/statsd/version_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Datadog::Statsd do
   describe 'VERSION' do
     it 'has a version' do
-      expect(Datadog::Statsd::VERSION).to match /\d+\.\d+\.\d+/
+      expect(Datadog::Statsd::VERSION).to match(/\d+\.\d+\.\d+/)
     end
   end
 end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1014,7 +1014,7 @@ describe Datadog::Statsd do
         it 'does not raise error' do
           expect do
             subject.event(title, text, options)
-          end.not_to raise_error(RuntimeError, /payload is too big/)
+          end.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
This PR resolves the following warnings:

* instance variable @variable_name not initialized
* ambiguous first argument; put parentheses or a space even after `/' operator
* Using `expect { }.not_to raise_error(SpecificErrorClass, message)` risks false positives

## Before

```bash
% ruby --version
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
% bundle exec rake >/dev/null 2>&1 | grep -i warning: | sed -E 's/^[.*]+//g' | sort -u
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/lib/datadog/statsd/forwarder.rb:67: warning: instance variable @telemetry not initialized
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/lib/datadog/statsd/sender.rb:105: warning: instance variable @flush_timer not initialized
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/lib/datadog/statsd/sender.rb:97: warning: instance variable @flush_timer not initialized
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/lib/datadog/statsd/timer.rb:44: warning: instance variable @thread not initialized
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/spec/statsd/version_spec.rb:6: warning: ambiguous first argument; put parentheses or a space even after `/' operator
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass, message)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/spec/statsd_spec.rb:1015:in `block (5 levels) in <top (required)>'.
%
```

```
% ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin20]
% bundle exec rake >/dev/null 2>&1 | grep -i warning: | sed -E 's/^[.*]+//g' | sort -u
/Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/spec/statsd/version_spec.rb:6: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass, message)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/arabiki/ghq/src/github.com/DataDog/dogstatsd-ruby/spec/statsd_spec.rb:1015:in `block (5 levels) in <top (required)>'.
%
```

## After

```bash
% ruby --version
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
% bundle exec rake >/dev/null 2>&1 | grep -i warning: | sed -E 's/^[.*]+//g' | sort -u
%
```

```bash
% ruby --version
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin20]
% bundle exec rake >/dev/null 2>&1 | grep -i warning: | sed -E 's/^[.*]+//g' | sort -u
%
```