### PR TITLE
Fix NoMethodError when Datadog::Statsd is initialized without telemetry

### DIFF
--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -9,7 +9,7 @@ module Datadog
       end
 
       def reset_telemetry
-        telemetry.reset
+        telemetry.reset if telemetry
       end
 
       # not thread safe: `Sender` instances that use this are required to properly synchronize or sequence calls to this method

--- a/spec/statsd/udp_connection_spec.rb
+++ b/spec/statsd/udp_connection_spec.rb
@@ -49,6 +49,23 @@ describe Datadog::Statsd::UDPConnection do
     end
   end
 
+  describe '#reset_telemetry' do
+    context 'when telemetry is set' do
+      it 'resets the telemetry' do
+        expect(telemetry).to receive(:reset)
+        subject.reset_telemetry
+      end
+    end
+
+    context 'when telemetry is not set' do
+      let(:telemetry) { nil }
+
+      it 'does not raise an error' do
+        expect { subject.reset_telemetry }.to_not raise_error
+      end
+    end
+  end
+
   describe '#write' do
     let(:telemetry) do
       instance_double(Datadog::Statsd::Telemetry, sent: true, dropped_writer: true)

--- a/spec/statsd/uds_connection_spec.rb
+++ b/spec/statsd/uds_connection_spec.rb
@@ -40,6 +40,23 @@ describe Datadog::Statsd::UDSConnection do
     end
   end
 
+  describe '#reset_telemetry' do
+    context 'when telemetry is set' do
+      it 'resets the telemetry' do
+        expect(telemetry).to receive(:reset)
+        subject.reset_telemetry
+      end
+    end
+
+    context 'when telemetry is not set' do
+      let(:telemetry) { nil }
+
+      it 'does not raise an error' do
+        expect { subject.reset_telemetry }.to_not raise_error
+      end
+    end
+  end
+
   describe '#write' do
     let(:telemetry) do
       instance_double(Datadog::Statsd::Telemetry, sent: true, dropped_writer: true)


### PR DESCRIPTION
When `Datadog::Statsd` is initialized with `telemetry_enable: false` a connection's telemetry is set to nil. The calls to telemetry in `connection.rb` guard against telemetry being nil except the one in `reset_telemetry`.

I had the NoMethodError happen when using the `SingleThreadSender` after forking a process and it attempting to reset the message_buffer. I haven't tested this against the `Sender` class but from looking at how that handles spawning the background thread it seems like a similar issue would happen with that.

I didn't come across existing tests for `reset_telemetry` so I added tests to both the udp and uds senders.

Please let me know if there are any changes needed to get the fix merged.