### PR TITLE
[BUG-275] Fix for UDS Sockets

### DIFF
--- a/lib/datadog/statsd/uds_connection.rb
+++ b/lib/datadog/statsd/uds_connection.rb
@@ -27,7 +27,7 @@ module Datadog
       def connect
         close if @socket
 
-        @socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+        @socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_STREAM)
         @socket.connect(Socket.pack_sockaddr_un(@socket_path))
       end
 

--- a/lib/datadog/statsd/version.rb
+++ b/lib/datadog/statsd/version.rb
@@ -4,6 +4,6 @@ require_relative 'connection'
 
 module Datadog
   class Statsd
-    VERSION = '5.5.0'
+    VERSION = '5.5.1'
   end
 end

--- a/spec/statsd/uds_connection_spec.rb
+++ b/spec/statsd/uds_connection_spec.rb
@@ -66,7 +66,7 @@ describe Datadog::Statsd::UDSConnection do
       expect(Socket)
         .to receive(:new)
         .once
-        .with(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+        .with(Socket::AF_UNIX, Socket::SOCK_STREAM)
 
       subject.write('test')
     end


### PR DESCRIPTION
Patch for : https://github.com/DataDog/dogstatsd-ruby/issues/275

This fixes unix domain socket writes.  The test cases on current master (9b3ae2dc) seem to give false positive test passes.  The existing code on master in uds_connection.rb does not work  in that calls to @socket.write do not send bytes to the domain socket for some reason:

```ruby
  @socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
  @socket.connect(Socket.pack_sockaddr_un(@socket_path))
```

This patch changes the use of `Socket` to `UNIXSocket` which does seem to work when testing manually and bytes show up on the listening domain socket.

