### PR TITLE
delay_serialization: implement feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 [//]: # (comment: Don't forget to update lib/datadog/statsd/version.rb:DogStatsd::Statsd::VERSION when releasing a new version)
 
+## 5.6.0 / 2023.06.07
+
+  * [FEATURE] Add the `delay_serialization` option, allowing users to delay
+    expensive serialization until a more convenient time, such as after an HTTP
+    request has completed. In multi-threaded mode, it causes serialization to
+    happen inside the sender thread. [#271][] by [@pudiva][] and
+    [@BlakeWilliams][]
+
+  * [FEATURE] Also, support the `sender_queue_size` in `single_thread` mode, so
+    that it can benefit from the new `delay_serialization` option. Messages are
+    now queued (possibly unserialized) until `sender_queue_size` is reached or
+    `#flush` is called. It may be set to `Float::INFINITY`, so that messages
+    are indefinitely queued until an explicit `#flush`. [#271][] by [@pudiva][]
+    and [@BlakeWilliams][]
+
 ## 5.5.0 / 2022.06.01
 
   * [FEATURE] Add `distribution_time` method to facilitate measuring timing of a yielded block. [#248][] by [@jordan-brough][]
@@ -431,6 +446,7 @@ Future versions are likely to introduce backward incompatibilities with < Ruby 1
 [#257]: https://github.com/DataDog/dogstatsd-ruby/issues/257
 [#258]: https://github.com/DataDog/dogstatsd-ruby/issues/258
 [#260]: https://github.com/DataDog/dogstatsd-ruby/issues/260
+[#271]: https://github.com/DataDog/dogstatsd-ruby/issues/271
 [@AMekss]: https://github.com/AMekss
 [@abicky]: https://github.com/abicky
 [@adimitrov]: https://github.com/adimitrov
@@ -469,3 +485,5 @@ Future versions are likely to introduce backward incompatibilities with < Ruby 1
 [@delner]: https://github.com/delner
 [@tenderlove]: https://github.com/tenderlove
 [@zachmccormick]: https://github.com/zachmccormick
+[@pudiva]: https://github.com/pudiva
+[@BlakeWilliams]: https://github.com/BlakeWilliams

--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -76,11 +76,12 @@ module Datadog
     # @option [Logger] logger for debugging
     # @option [Integer] buffer_max_payload_size max bytes to buffer
     # @option [Integer] buffer_max_pool_size max messages to buffer
-    # @option [Integer] sender_queue_size size of the sender queue in number of buffers (multi-thread only)
+    # @option [Integer] sender_queue_size size of the sender queue in number of buffers
     # @option [Numeric] buffer_flush_interval interval in second to flush buffer
     # @option [String] socket_path unix socket path
     # @option [Float] default sample rate if not overridden
     # @option [Boolean] single_thread flushes the metrics on the main thread instead of in a companion thread
+    # @option [Boolean] delay_serialization delays stat serialization
     def initialize(
       host = nil,
       port = nil,
@@ -100,6 +101,7 @@ module Datadog
       logger: nil,
 
       single_thread: false,
+      delay_serialization: false,
 
       telemetry_enable: true,
       telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL
@@ -112,6 +114,7 @@ module Datadog
       @prefix = @namespace ? "#{@namespace}.".freeze : nil
       @serializer = Serialization::Serializer.new(prefix: @prefix, global_tags: tags)
       @sample_rate = sample_rate
+      @delay_serialization = delay_serialization
 
       @forwarder = Forwarder.new(
         connection_cfg: ConnectionCfg.new(
@@ -133,6 +136,7 @@ module Datadog
         sender_queue_size: sender_queue_size,
 
         telemetry_flush_interval: telemetry_enable ? telemetry_flush_interval : nil,
+        serializer: serializer
       )
     end
 
@@ -425,7 +429,12 @@ module Datadog
       sample_rate = opts[:sample_rate] || @sample_rate || 1
 
       if sample_rate == 1 || opts[:pre_sampled] || rand <= sample_rate
-        full_stat = serializer.to_stat(stat, delta, type, tags: opts[:tags], sample_rate: sample_rate)
+        full_stat =
+          if @delay_serialization
+            [[stat, delta, type], {tags: opts[:tags], sample_rate: sample_rate}]
+          else
+            serializer.to_stat(stat, delta, type, tags: opts[:tags], sample_rate: sample_rate)
+          end
 
         forwarder.send_message(full_stat)
       end

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -21,7 +21,9 @@ module Datadog
 
         single_thread: false,
 
-        logger: nil
+        logger: nil,
+
+        serializer:
       )
         @transport_type = connection_cfg.transport_type
 
@@ -52,8 +54,10 @@ module Datadog
           max_payload_size: buffer_max_payload_size,
           max_pool_size: buffer_max_pool_size || DEFAULT_BUFFER_POOL_SIZE,
           overflowing_stategy: buffer_overflowing_stategy,
+          serializer: serializer
         )
 
+        sender_queue_size ||= 1 if single_thread
         sender_queue_size ||= (@transport_type == :udp ?
                                UDP_DEFAULT_SENDER_QUEUE_SIZE : UDS_DEFAULT_SENDER_QUEUE_SIZE)
 
@@ -61,7 +65,8 @@ module Datadog
           SingleThreadSender.new(
             buffer,
             logger: logger,
-            flush_interval: buffer_flush_interval) :
+            flush_interval: buffer_flush_interval,
+            queue_size: sender_queue_size) :
           Sender.new(
             buffer,
             logger: logger,

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -84,7 +84,10 @@ module Datadog
         if message_queue.length <= @queue_size
           message_queue << message
         else
-          @telemetry.dropped_queue(packets: 1, bytes: message.bytesize) if @telemetry
+          if @telemetry
+            bytesize = message.respond_to?(:bytesize) ? message.bytesize : 0
+            @telemetry.dropped_queue(packets: 1, bytes: bytesize)
+          end
         end
       end
 

--- a/lib/datadog/statsd/single_thread_sender.rb
+++ b/lib/datadog/statsd/single_thread_sender.rb
@@ -7,10 +7,12 @@ module Datadog
     # It is using current Process.PID to check it is the result of a recent fork
     # and it is reseting the MessageBuffer if that's the case.
     class SingleThreadSender
-      def initialize(message_buffer, logger: nil, flush_interval: nil)
+      def initialize(message_buffer, logger: nil, flush_interval: nil, queue_size: 1)
         @message_buffer = message_buffer
         @logger = logger
         @mx = Mutex.new
+        @message_queue_size = queue_size
+        @message_queue = []
         @flush_timer = if flush_interval
           Datadog::Statsd::Timer.new(flush_interval) { flush }
         else
@@ -26,15 +28,21 @@ module Datadog
           # not send, they belong to the parent process, let's clear the buffer.
           if forked?
             @message_buffer.reset
+            @message_queue.clear
             @flush_timer.start if @flush_timer && @flush_timer.stop?
             update_fork_pid
           end
-          @message_buffer.add(message)
+
+          @message_queue << message
+          if @message_queue.size >= @message_queue_size
+            drain_message_queue
+          end
         }
       end
 
       def flush(*)
         @mx.synchronize {
+          drain_message_queue
           @message_buffer.flush()
         }
       end
@@ -52,6 +60,12 @@ module Datadog
       end
 
       private
+
+      def drain_message_queue
+        while msg = @message_queue.shift
+          @message_buffer.add(msg)
+        end
+      end
 
       # below are "fork management" methods to be able to clean the MessageBuffer
       # if it detects that it is running in a unknown PID.

--- a/lib/datadog/statsd/version.rb
+++ b/lib/datadog/statsd/version.rb
@@ -4,6 +4,6 @@ require_relative 'connection'
 
 module Datadog
   class Statsd
-    VERSION = '5.5.0'
+    VERSION = '5.6.0'
   end
 end

--- a/spec/integrations/delay_serialization_spec.rb
+++ b/spec/integrations/delay_serialization_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe "Delayed serialization mode" do
+  it "defers serialization to message buffer" do
+    buffer = double(Datadog::Statsd::MessageBuffer)
+    # expects an Array is passed and not a String
+    expect(buffer)
+      .to receive(:add)
+      .with([["boo", 1, "c"], {tags: nil, sample_rate: 1}])
+    # and then expect no more adds!
+    expect(buffer).to receive(:add).exactly(0).times
+    expect(buffer)
+      .to receive(:flush)
+
+    allow(Datadog::Statsd::MessageBuffer).to receive(:new).and_return(buffer)
+    dogstats = Datadog::Statsd.new("localhost", 1234, delay_serialization: true)
+
+    dogstats.increment("boo")
+    dogstats.flush(sync: true)
+  end
+
+  it "serializes messages normally" do
+    socket = FakeUDPSocket.new(copy_message: true)
+    allow(UDPSocket).to receive(:new).and_return(socket)
+    dogstats = Datadog::Statsd.new("localhost", 1234, delay_serialization: true)
+
+    dogstats.increment("boo")
+    dogstats.increment("oob", tags: {tag1: "val1"})
+    dogstats.increment("pow", tags: {tag1: "val1"}, sample_rate: 2)
+    dogstats.flush(sync: true)
+
+    expect(socket.recv[0]).to eq([
+      "boo:1|c",
+      "oob:1|c|#tag1:val1",
+      "pow:1|c|@2|#tag1:val1"
+    ].join("\n"))
+  end
+end

--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -33,6 +33,10 @@ describe Datadog::Statsd::Forwarder do
     instance_double(Logger)
   end
 
+  let(:serializer) do
+    Datadog::Statsd::Serialization::Serializer.new
+  end
+
   before do
     allow(Datadog::Statsd::MessageBuffer)
       .to receive(:new)
@@ -94,6 +98,8 @@ describe Datadog::Statsd::Forwarder do
 
         logger: logger,
         global_tags: global_tags,
+
+        serializer: serializer,
       }
     end
 
@@ -277,6 +283,8 @@ describe Datadog::Statsd::Forwarder do
 
         logger: logger,
         global_tags: global_tags,
+
+        serializer: serializer,
       }
     end
 
@@ -464,6 +472,8 @@ describe Datadog::Statsd::Forwarder do
 
         logger: logger,
         global_tags: global_tags,
+
+        serializer: serializer,
       }
     end
 

--- a/spec/statsd/message_buffer_spec.rb
+++ b/spec/statsd/message_buffer_spec.rb
@@ -6,6 +6,7 @@ describe Datadog::Statsd::MessageBuffer do
       max_payload_size: max_payload_size,
       max_pool_size: max_pool_size,
       overflowing_stategy: overflowing_stategy,
+      serializer: serializer,
     )
   end
 
@@ -23,6 +24,10 @@ describe Datadog::Statsd::MessageBuffer do
 
   let(:overflowing_stategy) do
     :drop
+  end
+
+  let(:serializer) do
+    Datadog::Statsd::Serialization::Serializer.new
   end
 
   describe '#add' do


### PR DESCRIPTION
Add the `delay_serialization` option, allowing users to delay expensive serialization until a more convenient time, such as after an HTTP request has completed. In multi-threaded mode, it causes serialization to happen inside the sender thread.

Also, support the `sender_queue_size` in `single_thread` mode, so that it can benefit from the new `delay_serialization` option. Messages are now queued (possibly unserialized) until `sender_queue_size` is reached or `#flush` is called. It may be set to `Float::INFINITY`, so that messages are indefinitely queued until an explicit `#flush`.

Fix #271