### PR TITLE
Allow connections to IPv6 addresses

### DIFF
--- a/lib/datadog/statsd/udp_connection.rb
+++ b/lib/datadog/statsd/udp_connection.rb
@@ -29,7 +29,9 @@ module Datadog
       def connect
         close if @socket
 
-        @socket = UDPSocket.new
+        family = Addrinfo.udp(host, port).afamily
+
+        @socket = UDPSocket.new(family)
         @socket.connect(host, port)
       end
 

--- a/spec/statsd/udp_connection_spec.rb
+++ b/spec/statsd/udp_connection_spec.rb
@@ -71,6 +71,34 @@ describe Datadog::Statsd::UDPConnection do
       instance_double(Datadog::Statsd::Telemetry, sent: true, dropped_writer: true)
     end
 
+    context 'using an IPv6 address' do
+      let(:host) { '2001:db8::dead:beef' }
+
+      it 'connects to an IPv6 host with the right address family' do
+        expect(UDPSocket)
+          .to receive(:new)
+                .with(Socket::AF_INET6)
+
+        subject.write('test')
+      end
+
+      it 'connects to the right host and port' do
+        expect(udp_socket)
+          .to receive(:connect)
+                .with('2001:db8::dead:beef', 4567)
+
+        subject.write('test')
+      end
+    end
+
+    it 'connects to an IPv4 host with the right address family' do
+      expect(UDPSocket)
+        .to receive(:new)
+        .with(Socket::AF_INET)
+
+      subject.write('test')
+    end
+
     it 'connects to the right host and port' do
       expect(udp_socket)
         .to receive(:connect)


### PR DESCRIPTION
This pull request aims to fix a problem I ran into where `dogstatsd-ruby` was unable to submit metrics to an agent running on an IPv6-only Kubernetes cluster. `UDPSocket.new`, unlike its TCP counterpart, will not automatically choose the best/correct address family.

To remedy this, we call into `Addrinfo` to grab the appropriate family and then pass the parsed family over to UDPSocket. This will additionally work for DNS hostnames, but it will add a bit of time penalty due to the double-DNS lookup. This can be solved by using `Addrinfo.udp(host, port).connect`, but this broke far too many tests to be acceptable/solvable in one pull request.

I've attempted to attach tests for the IPv6 case, which should be satisfactory.

Let me know if anything else is needed!