### PR TITLE
Support space-separated DD_TAGS

### DIFF
--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -79,7 +79,7 @@ module Datadog
         def dd_tags(env = ENV)
           return {} unless dd_tags = env['DD_TAGS']
 
-          to_tags_hash(dd_tags.split(' '))
+          to_tags_hash(dd_tags.split(/[, ]/))
         end
 
         def default_tags(env = ENV)

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -79,7 +79,7 @@ module Datadog
         def dd_tags(env = ENV)
           return {} unless dd_tags = env['DD_TAGS']
 
-          to_tags_hash(dd_tags.split(','))
+          to_tags_hash(dd_tags.split(' '))
         end
 
         def default_tags(env = ENV)

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -79,7 +79,8 @@ module Datadog
         def dd_tags(env = ENV)
           return {} unless dd_tags = env['DD_TAGS']
 
-          to_tags_hash(dd_tags.split(/[, ]/))
+          separator = dd_tags.include?(',') ? ',' : ' '
+          to_tags_hash(dd_tags.split(separator))
         end
 
         def default_tags(env = ENV)

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -148,7 +148,7 @@ describe Datadog::Statsd::Serialization::TagSerializer do
       context 'when testing DD_TAGS' do
         around do |example|
           ClimateControl.modify(
-            'DD_TAGS' => 'ghi,team:qa'
+            'DD_TAGS' => 'ghi team:qa'
           ) do
             example.run
           end

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -145,7 +145,21 @@ describe Datadog::Statsd::Serialization::TagSerializer do
     end
 
     context '[testing management of env vars]' do
-      context 'when testing DD_TAGS' do
+      context 'when testing DD_TAGS with commas' do
+        around do |example|
+          ClimateControl.modify(
+            'DD_TAGS' => 'ghi,team:qa'
+          ) do
+            example.run
+          end
+        end
+
+        it 'correctly adds individual tags' do
+          expect(subject.format([])).to eq 'ghi,team:qa'
+        end
+      end
+
+      context 'when testing DD_TAGS with spaces' do
         around do |example|
           ClimateControl.modify(
             'DD_TAGS' => 'ghi team:qa'

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -78,7 +78,7 @@ describe Datadog::Statsd do
           'DD_ENV' => 'staging',
           'DD_SERVICE' => 'billing-service',
           'DD_VERSION' => '0.1.0-alpha',
-          'DD_TAGS' => 'ghi,team:qa'
+          'DD_TAGS' => 'ghi team:qa'
         ) do
           example.run
         end


### PR DESCRIPTION
# Problem

For logging, DD_TAGS [should be space separated](https://github.com/DataDog/datadog-agent/blob/21cb9b2ac809ed90a92b030bff59ee66e745e778/pkg/config/config_template.yaml#L129), per the docs. We changed to that on 11/16 and that's been working since. But at the same time we lost tagging on metrics because [they're required to be comma-separated](https://github.com/DataDog/dogstatsd-ruby/blob/3feb50f0bc44e5ac627a4397fb31e8295e63594e/lib/datadog/statsd/serialization/tag_serializer.rb#L82). (edited)

# Solution

Spaces have been in use since [datadog-agent 6.0](https://github.com/datadog/datadog-agent/commit/75fa4ea05a546e9e1b3c715898dcc0f1389b1b08#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR70-R71) in 2018. This PR adds space splitting to be consistent with datadog-agent expectations but keeps comma splitting to maintain backward compatibility.
