### PR TITLE
Update Statsd tag serializer to allow falsy values

### DIFF
--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -59,10 +59,10 @@ module Datadog
           case tags
           when Hash
             tags.map do |name, value|
-              if value
-                escape_tag_content("#{name}:#{value}")
-              else
+              if value&.to_s.nil?
                 escape_tag_content(name)
+              else
+                escape_tag_content("#{name}:#{value}")
               end
             end
           when Array
@@ -75,7 +75,7 @@ module Datadog
         def escape_tag_content(tag)
           tag = tag.to_s
           return tag unless tag.include?('|')
-          tag.delete('|,')        
+          tag.delete('|,')
         end
 
         def dd_tags(env = ENV)

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -59,10 +59,10 @@ module Datadog
           case tags
           when Hash
             tags.map do |name, value|
-              if value
-                escape_tag_content("#{name}:#{value}")
-              else
+              if value.nil?
                 escape_tag_content(name)
+              else
+                escape_tag_content("#{name}:#{value}")
               end
             end
           when Array

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -139,6 +139,20 @@ describe Datadog::Statsd::Serialization::TagSerializer do
         expect(subject.format([tag])).to eq 'node:storage'
       end
 
+      it 'ignores nil values and formats all other falsy values correctly' do
+        message_tags_hash = {
+          empty_array: [],
+          missing: nil,
+          'empty_hash' => {},
+          blank: '',
+          :false_value => false,
+          'results in blank': double('some tag', to_s: ''),
+          'results in nil': double('some tag', to_s: nil),
+        }
+
+        expect(subject.format(message_tags_hash)).to eq 'empty_array:[],missing,empty_hash:{},blank:,false_value:false,results in blank:,results in nil'
+      end
+
       it 'formats frozen tags correctly' do
         expect(subject.format(['name:foobarfoo'.freeze])).to eq 'name:foobarfoo'
       end

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -141,6 +141,18 @@ describe Datadog::Statsd::Serialization::TagSerializer do
         expect(subject.format([tag])).to eq 'node:storage'
       end
 
+      it 'serializes nil as a key-only tag and preserves false/empty values' do
+        message_tags_hash = {
+          empty_array: [],
+          missing: nil,
+          'empty_hash' => {},
+          'blank' => '',
+          false_value: false,
+        }
+
+        expect(subject.format(message_tags_hash)).to eq 'empty_array:[],missing,empty_hash:{},blank:,false_value:false'
+      end
+
       it 'formats frozen tags correctly' do
         expect(subject.format(['name:foobarfoo'.freeze])).to eq 'name:foobarfoo'
       end


### PR DESCRIPTION
## Problem
If we provide a tag which has a boolean value, we are unable to properly track the `false` case, since the "true" string appears with the tag name, but the "false" string does not show up. This is because of this logic, which checks for tag value presence:

https://github.com/DataDog/dogstatsd-ruby/blob/517b830c9b9103ff37c4b642bcfa5eff7c47353a/lib/datadog/statsd/serialization/tag_serializer.rb#L58-L66

`true` is evaluated to present, so we would add that tag name and value; however, `false` is evaluated to _not_ present, so we would only add that tag name (not the value).

## Solution
First, check for `nil` explicitly then also check for `nil` after converting to a string.

This does result in other values being deemed "present" now which were not previously though, such as `[]` and `{}`. Is this a problem though?