### PR TITLE
Reduce allocations during tag serialization

### DIFF
--- a/lib/datadog/statsd/serialization/stat_serializer.rb
+++ b/lib/datadog/statsd/serialization/stat_serializer.rb
@@ -38,16 +38,17 @@ module Datadog
         attr_reader :tag_serializer
 
         def formated_name(name)
-          if name.is_a?(String) && name.include?(':')
-            # DEV: gsub is faster than dup.gsub!
-            formated = name.gsub('::', '.')
-          else
-            formated = name.to_s
-            formated.gsub!('::', '.')
-          end
+          formated = name.is_a?(String) ? name : name.to_s
 
-          formated.tr!(':|@', '_')
-          formated
+          if formated.include?('::')
+            formated = formated.gsub('::', '.')
+            formated.tr!(':|@', '_')
+            formated
+          elsif formated.include?(':') || formated.include?('@') || formated.include?('|')
+            formated.tr(':|@', '_')
+          else
+            formated
+          end
         end
       end
     end

--- a/lib/datadog/statsd/serialization/stat_serializer.rb
+++ b/lib/datadog/statsd/serialization/stat_serializer.rb
@@ -38,7 +38,7 @@ module Datadog
         attr_reader :tag_serializer
 
         def formated_name(name)
-          if name.is_a?(String)
+          if name.is_a?(String) && name.include?(':')
             # DEV: gsub is faster than dup.gsub!
             formated = name.gsub('::', '.')
           else

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -73,6 +73,7 @@ module Datadog
         end
 
         def escape_tag_content(tag)
+          return tag.to_s unless tag.include?('|')
           tag.to_s.delete('|,')
         end
 

--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -73,8 +73,9 @@ module Datadog
         end
 
         def escape_tag_content(tag)
-          return tag.to_s unless tag.include?('|')
-          tag.to_s.delete('|,')
+          tag = tag.to_s
+          return tag unless tag.include?('|')
+          tag.delete('|,')
         end
 
         def dd_tags(env = ENV)

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -135,7 +135,7 @@ describe Datadog::Statsd::Serialization::TagSerializer do
       end
 
       it 'formats tags values with to_s' do
-        tag = double('some tag', to_s: 'node:storage')
+        tag = double('some tag', to_s: 'node:storage', include?: false)
         expect(subject.format([tag])).to eq 'node:storage'
       end
 


### PR DESCRIPTION
This PR reduces the string allocations in `TagSerializer` and `StatSerializer`. 

### TagSerializer 

The `TagSerializer` aims to remove `|,` from tags. The current implementation simply calls `#delete` to achieve that.

`delete` is [documented](https://ruby-doc.org/3.3.5/String.html#method-i-delete) as:
> Returns a copy of self with characters specified by selectors removed

Creating this copy unconditionally increases the amount of allocations.

This patch is checking the string for occurrences of `|` first and only leans on `delete` to remove them if at least one exists in the provided value.

The result is a reduction in allocation that can be measured with the benchmark spec.

<details>
  <summary>Before</summary>

```

ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Warming up --------------------------------------
             no tags     2.896M i/100ms
         global tags     2.908M i/100ms
          tags Array   177.431k i/100ms
           tags Hash   103.517k i/100ms
tags Array + global tags
                       129.709k i/100ms
tags Hash + global tags
                        82.158k i/100ms
Calculating -------------------------------------
             no tags     28.865M (± 5.7%) i/s -    144.809M in   5.034838s
         global tags     29.178M (± 2.9%) i/s -    148.331M in   5.088018s
          tags Array      1.762M (± 3.0%) i/s -      8.872M in   5.039047s
           tags Hash      1.084M (± 3.5%) i/s -      5.486M in   5.068419s
tags Array + global tags
                          1.293M (± 4.1%) i/s -      6.485M in   5.024175s
tags Hash + global tags
                        886.646k (± 4.5%) i/s -      4.437M in   5.014568s

Comparison:
         global tags: 29178293.0 i/s
             no tags: 28865172.6 i/s - same-ish: difference falls within error
          tags Array:  1762195.1 i/s - 16.56x  slower
tags Array + global tags:  1293024.5 i/s - 22.57x  slower
           tags Hash:  1083813.1 i/s - 26.92x  slower
tags Hash + global tags:   886646.1 i/s - 32.91x  slower

      measure IPS
Calculating -------------------------------------
             no tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         global tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
          tags Array   240.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
           tags Hash   400.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
tags Array + global tags
                       392.000  memsize (   200.000  retained)
                         6.000  objects (     5.000  retained)
                         4.000  strings (     3.000  retained)
tags Hash + global tags
                       552.000  memsize (   200.000  retained)
                         9.000  objects (     5.000  retained)
                         4.000  strings (     3.000  retained)

Comparison:
             no tags:          0 allocated
         global tags:          0 allocated - same
          tags Array:        240 allocated - Infx more
tags Array + global tags:        392 allocated - Infx more
           tags Hash:        400 allocated - Infx more
tags Hash + global tags:        552 allocated - Infx more
      measure memory

Finished in 42.05 seconds (files took 0.09661 seconds to load)
35 examples, 0 failures
```
</details>

<details>
  <summary>After</summary>

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Warming up --------------------------------------
             no tags     2.829M i/100ms
         global tags     2.950M i/100ms
          tags Array   245.805k i/100ms
           tags Hash   130.647k i/100ms
tags Array + global tags
                       167.383k i/100ms
tags Hash + global tags
                        99.813k i/100ms
Calculating -------------------------------------
             no tags     29.521M (± 2.5%) i/s -    149.917M in   5.081495s
         global tags     29.508M (± 3.3%) i/s -    147.479M in   5.003613s
          tags Array      2.368M (± 6.3%) i/s -     12.044M in   5.108053s
           tags Hash      1.184M (± 8.7%) i/s -      5.879M in   5.004052s
tags Array + global tags
                          1.636M (± 5.7%) i/s -      8.202M in   5.032487s
tags Hash + global tags
                          1.037M (± 3.5%) i/s -      5.190M in   5.012192s

Comparison:
             no tags: 29521056.2 i/s
         global tags: 29507653.9 i/s - same-ish: difference falls within error
          tags Array:  2368372.1 i/s - 12.46x  slower
tags Array + global tags:  1635891.9 i/s - 18.05x  slower
           tags Hash:  1184362.2 i/s - 24.93x  slower
tags Hash + global tags:  1036795.0 i/s - 28.47x  slower

      measure IPS
Calculating -------------------------------------
             no tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         global tags     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
          tags Array   120.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
           tags Hash   280.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
tags Array + global tags
                       272.000  memsize (    80.000  retained)
                         3.000  objects (     2.000  retained)
                         1.000  strings (     0.000  retained)
tags Hash + global tags
                       432.000  memsize (   240.000  retained)
                         6.000  objects (     5.000  retained)
                         4.000  strings (     3.000  retained)

Comparison:
             no tags:          0 allocated
         global tags:          0 allocated - same
          tags Array:        120 allocated - Infx more
tags Array + global tags:        272 allocated - Infx more
           tags Hash:        280 allocated - Infx more
tags Hash + global tags:        432 allocated - Infx more
      measure memory

Finished in 42.17 seconds (files took 0.09459 seconds to load)
35 examples, 0 failures
```

</details>

### StatSerializer

In a similar fashion `#formated_name` on the  `StatSerializer` leans on `gsub` to replace occurrences of `::` with `.`. Again, calling `gsub` unconditionaly increases the amount of allocations.

Checking for at least on occurrence of `:` in the provided string before calling `gsub` should help to eliminate the unnecessary allocations.

<details>
<summary>Before</summary>

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Warming up --------------------------------------
             no tags   246.222k i/100ms
no tags + sample rate
                       135.840k i/100ms
           with tags   121.692k i/100ms
with tags + sample rate
                        87.268k i/100ms
Calculating -------------------------------------
             no tags      2.453M (± 1.1%) i/s -     12.311M in   5.019483s
no tags + sample rate
                          1.352M (± 1.0%) i/s -      6.792M in   5.024122s
           with tags      1.205M (± 1.3%) i/s -      6.085M in   5.049843s
with tags + sample rate
                        858.004k (± 1.0%) i/s -      4.363M in   5.086079s

Comparison:
             no tags:  2452963.3 i/s
no tags + sample rate:  1352021.7 i/s - 1.81x  slower
           with tags:  1205120.3 i/s - 2.04x  slower
with tags + sample rate:   858004.1 i/s - 2.86x  slower

    measure IPS
Calculating -------------------------------------
             no tags   160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
no tags + sample rate
                       240.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
           with tags   360.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
with tags + sample rate
                       400.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)

Comparison:
             no tags:        160 allocated
no tags + sample rate:        240 allocated - 1.50x more
           with tags:        360 allocated - 2.25x more
with tags + sample rate:        400 allocated - 2.50x more
    measure memory

Finished in 28.17 seconds (files took 0.09 seconds to load)
8 examples, 0 failures
```
</details>

<details>
<summary>After</summary>

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Warming up --------------------------------------
             no tags   237.549k i/100ms
no tags + sample rate
                       132.296k i/100ms
           with tags   119.923k i/100ms
with tags + sample rate
                        86.377k i/100ms
Calculating -------------------------------------
             no tags      2.364M (± 1.3%) i/s -     11.877M in   5.025823s
no tags + sample rate
                          1.318M (± 0.9%) i/s -      6.615M in   5.019459s
           with tags      1.201M (± 0.9%) i/s -      6.116M in   5.094224s
with tags + sample rate
                        858.107k (± 0.9%) i/s -      4.319M in   5.033392s

Comparison:
             no tags:  2363708.9 i/s
no tags + sample rate:  1317941.3 i/s - 1.79x  slower
           with tags:  1200701.3 i/s - 1.97x  slower
with tags + sample rate:   858106.7 i/s - 2.75x  slower

    measure IPS
Calculating -------------------------------------
             no tags   120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
no tags + sample rate
                       200.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
           with tags   320.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
with tags + sample rate
                       360.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
             no tags:        120 allocated
no tags + sample rate:        200 allocated - 1.67x more
           with tags:        320 allocated - 2.67x more
with tags + sample rate:        360 allocated - 3.00x more
    measure memory

Finished in 28.04 seconds (files took 0.09122 seconds to load)
8 examples, 0 failures
```
</details>