### PR TITLE
Avoid allocations when using delay_serialization

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -431,7 +431,7 @@ module Datadog
       if sample_rate == 1 || opts[:pre_sampled] || rand <= sample_rate
         full_stat =
           if @delay_serialization
-            [[stat, delta, type], {tags: opts[:tags], sample_rate: sample_rate}]
+            [stat, delta, type, opts[:tags], sample_rate]
           else
             serializer.to_stat(stat, delta, type, tags: opts[:tags], sample_rate: sample_rate)
           end

--- a/lib/datadog/statsd/message_buffer.rb
+++ b/lib/datadog/statsd/message_buffer.rb
@@ -28,7 +28,8 @@ module Datadog
         # Serializes the message if it hasn't been already. Part of the
         # delay_serialization feature.
         if message.is_a?(Array)
-          message = @serializer.to_stat(*message[0], **message[1])
+          stat, delta, type, tags, sample_rate = message
+          message = @serializer.to_stat(stat, delta, type, tags: tags, sample_rate: sample_rate)
         end
 
         message_size = message.bytesize

--- a/spec/integrations/delay_serialization_spec.rb
+++ b/spec/integrations/delay_serialization_spec.rb
@@ -6,7 +6,7 @@ describe "Delayed serialization mode" do
     # expects an Array is passed and not a String
     expect(buffer)
       .to receive(:add)
-      .with([["boo", 1, "c"], {tags: nil, sample_rate: 1}])
+      .with(["boo", 1, "c", nil, 1])
     # and then expect no more adds!
     expect(buffer).to receive(:add).exactly(0).times
     expect(buffer)


### PR DESCRIPTION
Previously we would allocate 3 objects (2 arrays, 1 hash) when inserting into the queue. Instead, since the Hash shape is consistent we should be able to just allocate one Array to hold all 5 values.

``` ruby
require_relative "spec/support/fake_udp_socket"

$socket = FakeUDPSocket.new(copy_message: true)
def UDPSocket.new
  $socket
end

$dogstats = Datadog::Statsd.new("localhost", 1234, delay_serialization: true)

def benchmark_setup(x)
  dogstats = $dogstats
  tags_array = %w(host:storage network:gigabit request:xyz)
  tags_hash = { host: "storage", network: "gigabit", request: "xyz" }
  tags_empty = []

  x.report("no tags")    { dogstats.increment(tags_empty) }
  x.report("tags Array") { dogstats.increment(tags_array) }
  x.report("tags Hash")  { dogstats.increment(tags_hash) }
end

require 'benchmark/ips'

Benchmark.ips do |x|
  benchmark_setup(x)
end

require 'benchmark-memory'

Benchmark.memory do |x|
  benchmark_setup(x)
end
```

**Before**

```
❯ be ruby --yjit test.rb
ruby 3.3.2 (2024-05-30 revision e5a195edf6) +YJIT [arm64-darwin23]
Warming up --------------------------------------
             no tags   420.626k i/100ms
          tags Array   412.549k i/100ms
           tags Hash   416.774k i/100ms
Calculating -------------------------------------
             no tags      4.734M (± 2.6%) i/s  (211.23 ns/i) -     23.976M in   5.067920s
          tags Array      4.708M (± 1.5%) i/s  (212.40 ns/i) -     23.928M in   5.083482s
           tags Hash      4.672M (± 2.9%) i/s  (214.04 ns/i) -     23.339M in   5.000179s

/Users/jhawthorn/.gem/ruby/3.3.2/gems/memory_profiler-1.0.2/lib/memory_profiler/cli.rb:4: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of memory_profiler-1.0.2 to add base64 into its gemspec.
Calculating -------------------------------------
             no tags   240.000  memsize (   240.000  retained)
                         3.000  objects (     3.000  retained)
                         0.000  strings (     0.000  retained)
          tags Array   240.000  memsize (   240.000  retained)
                         3.000  objects (     3.000  retained)
                         0.000  strings (     0.000  retained)
           tags Hash   240.000  memsize (   240.000  retained)
                         3.000  objects (     3.000  retained)
                         0.000  strings (     0.000  retained)
```

**After**

```
❯ be ruby --yjit test.rb
ruby 3.3.2 (2024-05-30 revision e5a195edf6) +YJIT [arm64-darwin23]
Warming up --------------------------------------
             no tags   557.475k i/100ms
          tags Array   552.918k i/100ms
           tags Hash   552.373k i/100ms
Calculating -------------------------------------
             no tags      6.663M (± 2.6%) i/s  (150.09 ns/i) -     33.448M in   5.023893s
          tags Array      6.556M (± 2.2%) i/s  (152.54 ns/i) -     33.175M in   5.063217s
           tags Hash      6.489M (± 3.6%) i/s  (154.10 ns/i) -     32.590M in   5.029423s

/Users/jhawthorn/.gem/ruby/3.3.2/gems/memory_profiler-1.0.2/lib/memory_profiler/cli.rb:4: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of memory_profiler-1.0.2 to add base64 into its gemspec.
Calculating -------------------------------------
             no tags    80.000  memsize (    80.000  retained)
                         1.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
          tags Array    80.000  memsize (    80.000  retained)
                         1.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
           tags Hash    80.000  memsize (    80.000  retained)
                         1.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
```

cc @schlubbi @ywenc