### PR TITLE
Add conditional for when formatting metric name symbol

### DIFF
--- a/lib/datadog/statsd/serialization/stat_serializer.rb
+++ b/lib/datadog/statsd/serialization/stat_serializer.rb
@@ -37,13 +37,18 @@ module Datadog
         attr_reader :prefix
         attr_reader :tag_serializer
 
-        def formatted_metric_name(metric_name)
-          if Symbol === metric_name && metric_name.respond_to?(:name)
-            formatted = metric_name.name
-          else
-            formatted = metric_name.to_s
+        if RUBY_VERSION < '3'
+          def metric_name_to_string(metric_name)
+            metric_name.to_s
           end
+        else
+          def metric_name_to_string(metric_name)
+            metric_name.is_a?(Symbol) ? metric_name.name : metric_name.to_s
+          end
+        end
 
+        def formatted_metric_name(metric_name)
+          formatted = metric_name_to_string(metric_name)
           if formatted.include?('::')
             formatted = formatted.gsub('::', '.')
             formatted.tr!(':|@', '_')

--- a/lib/datadog/statsd/serialization/stat_serializer.rb
+++ b/lib/datadog/statsd/serialization/stat_serializer.rb
@@ -43,7 +43,7 @@ module Datadog
           end
         else
           def metric_name_to_string(metric_name)
-            metric_name.is_a?(Symbol) ? metric_name.name : metric_name.to_s
+            Symbol === metric_name ? metric_name.name : metric_name.to_s
           end
         end
 

--- a/lib/datadog/statsd/serialization/stat_serializer.rb
+++ b/lib/datadog/statsd/serialization/stat_serializer.rb
@@ -38,7 +38,11 @@ module Datadog
         attr_reader :tag_serializer
 
         def formatted_metric_name(metric_name)
-          formatted = Symbol === metric_name ? metric_name.name : metric_name.to_s
+          if Symbol === metric_name && metric_name.respond_to?(:name)
+            formatted = metric_name.name
+          else
+            formatted = metric_name.to_s
+          end
 
           if formatted.include?('::')
             formatted = formatted.gsub('::', '.')

--- a/spec/statsd/serialization/stat_serializer_spec.rb
+++ b/spec/statsd/serialization/stat_serializer_spec.rb
@@ -108,6 +108,20 @@ describe Datadog::Statsd::Serialization::StatSerializer do
         expect(input).to eq 'somecount:|@test'
       end
     end
+
+    context "when metric name is a symbol" do
+      it 'formats correctly without error' do
+        input = :'somecount::test'
+        output = subject.format(input, 1, 'c')
+        expect(output).to eq 'somecount.test:1|c'
+        expect(input).to eq :'somecount::test'
+
+        input = :'somecount:|@test'
+        output = subject.format(input, 1, 'c')
+        expect(output).to eq 'somecount___test:1|c'
+        expect(input).to eq :'somecount:|@test'
+      end
+    end
   end
 
   context 'benchmark' do

--- a/spec/statsd/serialization/stat_serializer_spec.rb
+++ b/spec/statsd/serialization/stat_serializer_spec.rb
@@ -114,12 +114,10 @@ describe Datadog::Statsd::Serialization::StatSerializer do
         input = :'somecount::test'
         output = subject.format(input, 1, 'c')
         expect(output).to eq 'somecount.test:1|c'
-        expect(input).to eq :'somecount::test'
 
         input = :'somecount:|@test'
         output = subject.format(input, 1, 'c')
         expect(output).to eq 'somecount___test:1|c'
-        expect(input).to eq :'somecount:|@test'
       end
     end
   end


### PR DESCRIPTION
Fixes an issue where `{Symbol}.name` breaks in `RUBY_VERSION < 3`. 

Was not caught in CI since we didn't use symbols in our testing so I've added a new test.