### PR TITLE
[Bugfix] Delete commas when escaping tag content

### DIFF
--- a/lib/datadog/statsd/serialization/tag_serializer.rb
+++ b/lib/datadog/statsd/serialization/tag_serializer.rb
@@ -74,8 +74,8 @@ module Datadog
 
         def escape_tag_content(tag)
           tag = tag.to_s
-          return tag unless tag.include?('|')
-          tag.delete('|,')        
+          return tag unless tag.include?('|') || tag.include?(',')
+          tag.delete('|,')
         end
 
         def dd_tags(env = ENV)

--- a/spec/statsd/serialization/tag_serializer_spec.rb
+++ b/spec/statsd/serialization/tag_serializer_spec.rb
@@ -132,6 +132,8 @@ describe Datadog::Statsd::Serialization::TagSerializer do
     context '[testing serialization edge cases]' do
       it 'formats tags with reserved characters' do
         expect(subject.format(['name:foo,bar|foo'])).to eq 'name:foobarfoo'
+        expect(subject.format(['name:foobar|foo'])).to eq 'name:foobarfoo'
+        expect(subject.format(['name:foo, bar, and foo'])).to eq 'name:foo bar and foo'
       end
 
       it 'formats tags values with to_s' do


### PR DESCRIPTION
Addresses issue https://github.com/DataDog/dogstatsd-ruby/issues/300

https://github.com/DataDog/dogstatsd-ruby/pull/294 introduced a change wherein commas (`,`) are no longer deleted from tags unless that tag includes a pipe char (`|`). This causes tags containing commas to report differently than before the change, resulting in data misalignment.

This change will delete commas (again) if they are included in the tag string.