### PR TITLE
Rescue ThreadError when creating Sender Thread

### DIFF
--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -69,6 +69,8 @@ module Datadog
         # the parent process) and spawn a new companion thread.
         if !sender_thread.alive?
           @mx.synchronize {
+            # an attempt was previously made to start the sender thread but failed.
+            # skipping re-start
             break if @done
             # a call from another thread has already re-created
             # the companion thread before this one acquired the lock
@@ -109,8 +111,7 @@ module Datadog
           end
           @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
         rescue ThreadError => e
-          @logger.debug { "Statsd: Failed to start sender thread: #{e.message}, flushing message buffer" } if @logger
-          message_buffer.flush
+          @logger.debug { "Statsd: Failed to start sender thread: #{e.message}" } if @logger
         end
 
         @flush_timer.start if @flush_timer

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -102,12 +102,7 @@ module Datadog
         @message_queue = @queue_class.new
         begin
           # start background thread
-          @sender_thread = @thread_class.new do
-            begin
-              send_loop
-            ensure
-            end
-          end
+          @sender_thread = @thread_class.new(&method(:send_loop))
           @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
         rescue ThreadError => e
           @logger.debug { "Statsd: Failed to start sender thread: #{e.message}" } if @logger

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -68,6 +68,11 @@ module Datadog
         # the parent process) and spawn a new companion thread.
         if !sender_thread.alive?
           @mx.synchronize {
+            # if the sender_thread was terminated due to an exception, we don't want to re-start it 
+            if sender_thread.status.nil?
+              @logger.debug { "Statsd: sender_thread was terminated due to exception, skipping sender_thread re-start."} if @logger
+              return
+            end
             # a call from another thread has already re-created
             # the companion thread before this one acquired the lock
             break if sender_thread.alive?

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -100,8 +100,8 @@ module Datadog
           # start background thread
           @sender_thread = @thread_class.new(&method(:send_loop))
           @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-        rescue ThreadError
-          @logger.debug { "Statsd: Failed to start sender thread, flushing message buffer" } if @logger
+        rescue ThreadError => e
+          @logger.debug { "Statsd: Failed to start sender thread: #{e.message}, flushing message buffer" } if @logger
           message_buffer.flush
         end
 

--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -96,9 +96,15 @@ module Datadog
 
         # initialize a new message queue for the background thread
         @message_queue = @queue_class.new
-        # start background thread
-        @sender_thread = @thread_class.new(&method(:send_loop))
-        @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+        begin
+          # start background thread
+          @sender_thread = @thread_class.new(&method(:send_loop))
+          @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+        rescue ThreadError
+          @logger.debug { "Statsd: Failed to start sender thread, flushing message buffer" } if @logger
+          message_buffer.flush
+        end
+
         @flush_timer.start if @flush_timer
       end
 

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -62,6 +62,22 @@ describe Datadog::Statsd::Sender do
       end
     end
 
+    context 'when a ThreadError is raised starting the sender thread' do
+      let(:thread_class) do
+        class_double(Thread)
+      end
+
+      before do
+        allow(thread_class).to receive(:new).and_raise(ThreadError, "ThreadError")
+      end
+
+      it 'ignores the thread error' do
+        expect do
+          subject.start
+        end.not_to raise_error
+      end
+    end
+
     context 'when flush_interval is set' do
       let(:flush_interval) { 0.001 }
 

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -92,7 +92,10 @@ describe Datadog::Statsd::Sender do
 
         it 'does not store the message' do
           subject.start
-          expect(fake_queue).not_to receive(:<<)
+          expect(fake_queue).not_to receive(:<<).with('message')
+          if not Queue.instance_methods.include?(:close)
+            expect(fake_queue).to receive(:<<).with(:close)
+          end
           subject.add('message')
         end
       end


### PR DESCRIPTION
This pr introduces a change to handle the case in which `sender_thread` fails to start and a `ThreadError` is returned. 

Addresses issue #306 authored by @mperham 