### PR TITLE
Mark sender and timer threads as fork safe for Puma

### DIFF
--- a/lib/datadog/statsd/sender.rb
+++ b/lib/datadog/statsd/sender.rb
@@ -51,7 +51,7 @@ module Datadog
         # could happen if #start hasn't be called
         return unless message_queue
 
-        # Initialize and get the thread's sync queue
+        # initialize and get the thread's sync queue
         queue = (@thread_class.current[:statsd_sync_queue] ||= @queue_class.new)
         # tell sender-thread to notify us in the current
         # thread's queue
@@ -104,6 +104,9 @@ module Datadog
           # start background thread
           @sender_thread = @thread_class.new(&method(:send_loop))
           @sender_thread.name = "Statsd Sender" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+          # advise multi-threaded app servers to ignore this thread for the purposes of fork safety warnings
+          # see Puma's implementation for `:fork_safe`: https://github.com/puma/puma/blob/v7.2.0/lib/puma/cluster.rb#L374
+          @sender_thread.thread_variable_set(:fork_safe, true)
         rescue ThreadError => e
           @logger.debug { "Statsd: Failed to start sender thread: #{e.message}" } if @logger
           @mx.synchronize { @done = true }

--- a/lib/datadog/statsd/timer.rb
+++ b/lib/datadog/statsd/timer.rb
@@ -28,6 +28,9 @@ module Datadog
           end
         end
         @thread.name = 'Statsd Timer' unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+        # advise multi-threaded app servers to ignore this thread for the purposes of fork safety warnings
+        # see Puma's implementation for `:fork_safe`: https://github.com/puma/puma/blob/v7.2.0/lib/puma/cluster.rb#L374
+        @thread.thread_variable_set(:fork_safe, true)
       end
 
       def stop

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -48,6 +48,13 @@ describe Datadog::Statsd::Sender do
           |thds| thds.any? { |t| t.name == "Statsd Sender" }
         }
       end
+
+      it 'marks the sender thread as fork safe' do
+        subject.start
+        expect(Thread.list).to satisfy {
+          |thds| thds.any? { |t| t.name == "Statsd Sender" && t.thread_variable_get(:fork_safe) }
+        }
+      end
     end
 
     context 'when the sender is started' do
@@ -204,9 +211,9 @@ describe Datadog::Statsd::Sender do
 
         let(:thread_class) do
           if Thread.instance_methods.include?(:name=)
-            fake_thread = instance_double(Thread, { "alive?" => true, "name=" => true, "join" => true })
+            fake_thread = instance_double(Thread, { "alive?" => true, "name=" => true, "join" => true, "thread_variable_set" => true })
           else
-            fake_thread = instance_double(Thread, { "alive?" => true, "join" => true })
+            fake_thread = instance_double(Thread, { "alive?" => true, "join" => true, "thread_variable_set" => true })
           end
           class_double(Thread, new: fake_thread)
         end

--- a/spec/statsd/sender_spec.rb
+++ b/spec/statsd/sender_spec.rb
@@ -35,6 +35,12 @@ describe Datadog::Statsd::Sender do
       end.to change { Thread.list.size }.by(1)
     end
 
+    it 'marks the sender thread as fork safe' do
+      expect do
+        subject.start
+      end.to change { Thread.list.count { |t| t.thread_variable_get(:fork_safe) } }.by(1)
+    end
+
     context 'on Ruby >= 2.3' do
       before do
         if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
@@ -204,9 +210,9 @@ describe Datadog::Statsd::Sender do
 
         let(:thread_class) do
           if Thread.instance_methods.include?(:name=)
-            fake_thread = instance_double(Thread, { "alive?" => true, "name=" => true, "join" => true })
+            fake_thread = instance_double(Thread, { "alive?" => true, "name=" => true, "join" => true, "thread_variable_set" => true })
           else
-            fake_thread = instance_double(Thread, { "alive?" => true, "join" => true })
+            fake_thread = instance_double(Thread, { "alive?" => true, "join" => true, "thread_variable_set" => true })
           end
           class_double(Thread, new: fake_thread)
         end

--- a/spec/statsd/timer_spec.rb
+++ b/spec/statsd/timer_spec.rb
@@ -54,6 +54,12 @@ describe Datadog::Statsd::Timer do
         expect(third_call_time - second_call_time).to be_within(0.03).of(0)
       end
     end
+
+    it 'marks the timer thread as fork safe' do
+      expect do
+        subject.start
+      end.to change { Thread.list.count { |t| t.thread_variable_get(:fork_safe) } }.by(1)
+    end
   end
 
   describe '#stop' do


### PR DESCRIPTION
We're in the process of enabling Puma's `preload_app!` config at @buildkite. When auditing threads spawned during boot, Puma flagged this gem's sender thread as potentially not `fork` safe. However, based on the documentation for this gem and the implementation of `Datadog::Statsd::Sender#add`, the sender thread appears `fork` safe to me. The same reasoning applies to the `Statsd Timer` thread used when `buffer_flush_interval` is configured, since `Sender#add` also restarts the flush timer after a fork.

This PR adds a `:fork_safe` thread variable to both threads, which Puma uses to exclude them from its safety reporting, so that anyone else auditing their threads this way won't see false positives from this gem.

Refs:
- How Puma uses the variable: https://github.com/puma/puma/blob/97c7d129a940c809fb379b3ecf314d39a18a332b/lib/puma/cluster.rb#L370-L379
- How Rails sets the variable: https://github.com/rails/rails/blob/8bf7a3d4d5760da094031681d354a4e148c2ded6/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb#L42-L44