### PR TITLE
[AGTMETRICS-209]Suppress external env if origin detection is configured off.

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -124,7 +124,7 @@ module Datadog
       origin_detection_enabled = origin_detection_enabled?(origin_detection)
       container_id = get_container_id(container_id, origin_detection_enabled)
 
-      external_data = sanitize(ENV['DD_EXTERNAL_ENV'])
+      external_data = sanitize(ENV['DD_EXTERNAL_ENV']) if origin_detection_enabled
 
       @serializer = Serialization::Serializer.new(prefix: @prefix,
                                                   container_id: container_id,

--- a/lib/datadog/statsd/telemetry.rb
+++ b/lib/datadog/statsd/telemetry.rb
@@ -40,7 +40,7 @@ module Datadog
       end
 
       def would_fit_in?(max_buffer_payload_size)
-        MAX_TELEMETRY_MESSAGE_SIZE_WT_TAGS + serialized_tags.size < max_buffer_payload_size
+        MAX_TELEMETRY_MESSAGE_SIZE_WT_TAGS + serialized_tags.size + serialized_fields.size < max_buffer_payload_size
       end
 
       def reset

--- a/spec/matchers/telemetry_matcher.rb
+++ b/spec/matchers/telemetry_matcher.rb
@@ -16,20 +16,24 @@ RSpec::Matchers.define :eq_with_telemetry do |expected_message, telemetry_option
                     packets_dropped: 0,
                     packets_dropped_queue: 0,
                     packets_dropped_writer: 0,
-                    transport: 'udp')
+                    transport: 'udp',
+                    external_env: '',
+                    container: '')
+    external_env = "|e:#{external_env}" unless external_env.empty?
+    container = "|c:#{container}" unless container.empty?
     [
       text,
-      "datadog.dogstatsd.client.metrics:#{metrics}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.events:#{events}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.service_checks:#{service_checks}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.bytes_sent:#{bytes_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.bytes_dropped:#{bytes_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.bytes_dropped_queue:#{bytes_dropped_queue}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.bytes_dropped_writer:#{bytes_dropped_writer}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.packets_sent:#{packets_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.packets_dropped:#{packets_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.packets_dropped_queue:#{packets_dropped_queue}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
-      "datadog.dogstatsd.client.packets_dropped_writer:#{packets_dropped_writer}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}",
+      "datadog.dogstatsd.client.metrics:#{metrics}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.events:#{events}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.service_checks:#{service_checks}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.bytes_sent:#{bytes_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.bytes_dropped:#{bytes_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.bytes_dropped_queue:#{bytes_dropped_queue}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.bytes_dropped_writer:#{bytes_dropped_writer}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.packets_sent:#{packets_sent}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.packets_dropped:#{packets_dropped}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.packets_dropped_queue:#{packets_dropped_queue}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
+      "datadog.dogstatsd.client.packets_dropped_writer:#{packets_dropped_writer}|c|#client:ruby,client_version:#{Datadog::Statsd::VERSION},client_transport:#{transport}#{container}#{external_env}",
     ].join("\n")
   end
 


### PR DESCRIPTION
If Origin Detection is configured to be off, we should not output the external env value.

Added some extra tests, which also highlighted the issue that with external env included we now have to send internal telemetry in 2 payloads over UDP since it now exceeds the max payload size for UDP which is likely a slight hit to performance. Don't think there's much we can do about it, other than use UDS where possible.