### PR TITLE
feat: support telemetry-specific metrics tags

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -109,6 +109,7 @@ module Datadog
 
       telemetry_enable: true,
       telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL,
+      telemetry_tags: nil,
 
       origin_detection: true,
       container_id: nil,
@@ -157,6 +158,7 @@ module Datadog
         sender_queue_size: sender_queue_size,
 
         telemetry_flush_interval: telemetry_enable ? telemetry_flush_interval : nil,
+        telemetry_tags: telemetry_tags,
         container_id: container_id,
         external_data: external_data,
         cardinality: @cardinality,

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -17,6 +17,8 @@ module Datadog
         sender_queue_size: nil,
 
         telemetry_flush_interval: nil,
+        telemetry_tags: [],
+
         global_tags: [],
 
         single_thread: false,
@@ -35,7 +37,7 @@ module Datadog
             container_id,
             external_data,
             cardinality,
-            global_tags: global_tags,
+            global_tags: global_tags + telemetry_tags,
             transport_type: @transport_type
           )
         else


### PR DESCRIPTION
We have a use case for sending tags specific to the telemetry metrics. Currently, the global tags aren't enough for us to identify specific hosts, but we don't want to add high-cardinality client-specific tags to every metric that we send.

This PR proposes adding `telemetry_tags` as a named parameter to the initializer. The forwarder then passes `global_tags + telemetry_tags` into the `Telemetry` object.