### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,3 @@
 
 # All files reviwed by maintainers
 *                     @DataDog/agent-metric-pipelines
-
-# Documentation includes docs team
-*.md                  @DataDog/documentation


### PR DESCRIPTION
Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.